### PR TITLE
Remove unused imports, add logging & fix deps

### DIFF
--- a/components/nav-user.tsx
+++ b/components/nav-user.tsx
@@ -20,8 +20,7 @@ import { authClient } from "@/lib/auth-client";
 import {
   EllipsisVerticalIcon,
   CircleUserRoundIcon,
-  CreditCardIcon,
-  BellIcon,
+  // CreditCardIcon และ BellIcon ถูกลบออก — ยังไม่ได้ใช้ในเมนู dropdown
   LogOutIcon,
 } from "lucide-react";
 import { toast } from "sonner";

--- a/lib/permissions.ts
+++ b/lib/permissions.ts
@@ -2,7 +2,7 @@ import { createAccessControl } from "better-auth/plugins/access";
 import {
   defaultStatements,
   adminAc,
-  userAc,
+  // userAc ถูกลบออก — ยังไม่ได้ใช้งานในการกำหนด role ปัจจุบัน
 } from "better-auth/plugins/admin/access";
 
 const statement = {

--- a/modules/auth/components/BanUserDialog.tsx
+++ b/modules/auth/components/BanUserDialog.tsx
@@ -7,7 +7,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
+  // DialogTrigger ไม่ได้ใช้ — Dialog ถูกควบคุมด้วย isBanUserDialogOpen prop
 } from "@/components/ui/dialog";
 import {
   Field,
@@ -16,13 +16,13 @@ import {
   FieldLabel,
 } from "@/components/ui/field";
 import { Input } from "@/components/ui/input";
-import { Ban } from "lucide-react";
+// Ban icon ถูกลบออก — ไม่ได้ใช้แสดงในปุ่มหรือ label ใดๆ
 import { Button } from "@/components/ui/button";
 import { Controller, useForm } from "react-hook-form";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "sonner";
 import { authClient } from "@/lib/auth-client";
-import { useState } from "react";
+// useState ถูกลบออก — state ถูกจัดการผ่าน prop setIsBanUserDialogOpen
 import { useRouter } from "next/navigation";
 
 const DAY_TO_SECONDS = 60 * 60 * 24;

--- a/modules/customer/components/CustomerDetail.tsx
+++ b/modules/customer/components/CustomerDetail.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { ChevronLeft, UserX } from "lucide-react";
+// UserX icon ถูกลบออก — ฟีเจอร์ unlink customer ยังไม่ได้พัฒนา
+import { ChevronLeft } from "lucide-react";
 import { PetInfoForm } from "@/modules/pet/components/PetInfoForm";
 import { PetBreed } from "@/modules/pet-breed/types/pet-breed";
 import { Pet } from "@/modules/pet/types/pet";

--- a/modules/customer/components/CustomerManagement.tsx
+++ b/modules/customer/components/CustomerManagement.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Separator } from "@/components/ui/separator";
+// Separator ถูกลบออก — ไม่ได้ใช้งานใน layout ปัจจุบัน
 import {
   Table,
   TableBody,

--- a/modules/customer/components/DeleteCustomerDialog.tsx
+++ b/modules/customer/components/DeleteCustomerDialog.tsx
@@ -9,7 +9,7 @@ import {  AlertDialog,
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Button } from "@/components/ui/button";
+// Button ถูกลบออก — ใช้ AlertDialogAction/AlertDialogCancel แทน
 import { toast } from "sonner";
 import { deleteCustomer } from "../actions/delete-customer";
 import { useRouter } from "next/navigation";

--- a/modules/pet-breed/components/CreatePetBreedDialog.tsx
+++ b/modules/pet-breed/components/CreatePetBreedDialog.tsx
@@ -14,7 +14,7 @@ import {
 import { Input } from "@/components/ui/input";
 import {
   Field,
-  FieldContent,
+  // FieldContent ถูกลบออก — ไม่มี field ที่ต้องการ wrapper นี้ใน CreatePetBreedDialog
   FieldError,
   FieldGroup,
   FieldLabel,

--- a/modules/pet-breed/components/DeletePetBreedDialog.tsx
+++ b/modules/pet-breed/components/DeletePetBreedDialog.tsx
@@ -9,9 +9,9 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
+  // AlertDialogTrigger ไม่ได้ใช้ — Dialog ถูกควบคุมด้วย open prop จากภายนอก
 } from "@/components/ui/alert-dialog";
-import { Button } from "@/components/ui/button";
+// Button ไม่ได้ใช้โดยตรง — ใช้ AlertDialogAction/Cancel แทน
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { useTransition } from "react";

--- a/modules/pet-breed/components/PetBreedManagement.tsx
+++ b/modules/pet-breed/components/PetBreedManagement.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Separator } from "@/components/ui/separator";
+// Separator ถูกลบออก — ไม่ได้ใช้งานใน layout ปัจจุบัน
 import {
   Table,
   TableBody,

--- a/modules/pet-breed/components/UpdatePetBreedDialog.tsx
+++ b/modules/pet-breed/components/UpdatePetBreedDialog.tsx
@@ -13,7 +13,7 @@ import {
 import { Input } from "@/components/ui/input";
 import {
   Field,
-  FieldContent,
+  // FieldContent ถูกลบออก — ไม่มี field ที่ต้องการ wrapper นี้ใน UpdatePetBreedDialog
   FieldError,
   FieldGroup,
   FieldLabel,

--- a/modules/pet/components/DeletePetDialog.tsx
+++ b/modules/pet/components/DeletePetDialog.tsx
@@ -8,13 +8,13 @@ import {  AlertDialog,
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
+  // AlertDialogTrigger ไม่ได้ใช้ — Dialog ถูกควบคุมด้วย open prop จากภายนอก
 } from "@/components/ui/alert-dialog";
-import { Button } from "@/components/ui/button";
+// Button ไม่ได้ใช้โดยตรง — ใช้ AlertDialogAction/Cancel แทน
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { useTransition } from "react";
-import { customer } from "@/lib/permissions";
+// customer (from permissions) ถูกลบออก — ไม่เกี่ยวข้องกับการลบสัตว์เลี้ยง
 import { deletePet } from "../actions/delete-pet";
 
 interface DeletePetDialogProps {

--- a/modules/pet/components/UpdatePetDialog.tsx
+++ b/modules/pet/components/UpdatePetDialog.tsx
@@ -9,17 +9,17 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
+  // DialogTrigger ไม่ได้ใช้ — Dialog นี้ถูกควบคุมด้วย open prop จากภายนอก
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
   Field,
-  FieldContent,
+  // FieldContent ถูกลบออกเนื่องจากไม่ได้ใช้งานในคอมโพเนนต์นี้
   FieldError,
   FieldGroup,
   FieldLabel,
 } from "@/components/ui/field";
-import { PencilIcon } from "lucide-react";
+// PencilIcon ถูกลบออก — ไม่ได้ใช้ภายใน UpdatePetDialog (trigger อยู่ที่ parent component)
 import { useEffect, useState } from "react";
 import { Separator } from "@/components/ui/separator";
 import { Controller, useForm } from "react-hook-form";

--- a/modules/pet/queries/list-pets.ts
+++ b/modules/pet/queries/list-pets.ts
@@ -31,6 +31,7 @@ export async function listPets(customerId: string): Promise<ActionResponse<Pet[]
       data: petsData,
     };
   } catch (error) {
+    console.error("listPets error:", error);
     return {
       success: false,
       error: "เกิดข้อผิดพลาดในการดึงข้อมูลสัตว์เลี้ยง",

--- a/modules/service/actions/update-service-variant.ts
+++ b/modules/service/actions/update-service-variant.ts
@@ -1,10 +1,8 @@
 "use server";
 
 import { db } from "@/db";
-import {
-  ServiceVariant,
-  UpdateServiceVariantForm,
-} from "../types/service-variant";
+// import เฉพาะ ServiceVariant เพราะ UpdateServiceVariantForm ไม่ได้ใช้ใน action นี้
+import { ServiceVariant } from "../types/service-variant";
 import { serviceVariants } from "@/db/schema";
 import { and, eq, isNull } from "drizzle-orm";
 import { ActionResponse } from "@/types/action";

--- a/modules/service/actions/update-service.ts
+++ b/modules/service/actions/update-service.ts
@@ -2,7 +2,8 @@
 
 import { db } from "@/db";
 import { services } from "@/db/schema";
-import { Service, ServiceForm } from "../types/service";
+// import เฉพาะ Service เพราะ ServiceForm ไม่ได้ใช้ใน action นี้
+import { Service } from "../types/service";
 import { ActionResponse } from "@/types/action";
 import { and, eq, isNull } from "drizzle-orm";
 

--- a/modules/service/components/CreateServiceDialog.tsx
+++ b/modules/service/components/CreateServiceDialog.tsx
@@ -14,7 +14,7 @@ import {
 import { Input } from "@/components/ui/input";
 import {
   Field,
-  FieldContent,
+  // FieldContent ถูกลบออกเนื่องจากไม่ได้ใช้งานในคอมโพเนนต์นี้
   FieldError,
   FieldGroup,
   FieldLabel,

--- a/modules/service/components/CreateServiceVariantDialog.tsx
+++ b/modules/service/components/CreateServiceVariantDialog.tsx
@@ -14,7 +14,7 @@ import {
 import { Input } from "@/components/ui/input";
 import {
   Field,
-  FieldContent,
+  // FieldContent ถูกลบออกเนื่องจากไม่ได้ใช้งานในคอมโพเนนต์นี้
   FieldError,
   FieldGroup,
   FieldLabel,
@@ -34,9 +34,10 @@ import {
 } from "@/components/ui/select";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
-import { Textarea } from "@/components/ui/textarea";
+// Textarea ถูกลบออกเพราะไม่มี field ที่ต้องการ textarea ในฟอร์มนี้
 import { createServiceVariant } from "../actions/create-service-variant";
-import { ServiceVariant, ServiceVariantForm } from "../types/service-variant";
+// import เฉพาะ ServiceVariantForm — ServiceVariant ไม่ได้ใช้โดยตรง
+import { ServiceVariantForm } from "../types/service-variant";
 
 interface CreateServiceVariantDialogProps {
   serviceId: string;

--- a/modules/service/components/DeleteServiceDialog.tsx
+++ b/modules/service/components/DeleteServiceDialog.tsx
@@ -9,9 +9,9 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
+  // AlertDialogTrigger ไม่ได้ใช้ — Dialog นี้ถูกควบคุมด้วย open prop จากภายนอก
 } from "@/components/ui/alert-dialog";
-import { Button } from "@/components/ui/button";
+// Button ไม่ได้ใช้โดยตรง — ใช้ AlertDialogAction/Cancel แทน
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { useTransition } from "react";

--- a/modules/service/components/ServiceManagement.tsx
+++ b/modules/service/components/ServiceManagement.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Separator } from "@/components/ui/separator";
+// Separator ถูกลบออกเนื่องจากไม่ได้ใช้งานใน JSX ของคอมโพเนนต์นี้
 import {
   Table,
   TableBody,

--- a/modules/service/components/ServiceVariantManagement.tsx
+++ b/modules/service/components/ServiceVariantManagement.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Separator } from "@/components/ui/separator";
+// Separator ถูกลบออกเนื่องจากไม่ได้ใช้งานใน JSX ของคอมโพเนนต์นี้
 import {
   Table,
   TableBody,
@@ -8,7 +8,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { PencilIcon, Settings, TrashIcon } from "lucide-react";
+// Settings icon ถูกลบออก — ไม่มีปุ่มจัดการ settings ใน ServiceVariant management
+import { PencilIcon, TrashIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useState } from "react";
 import Link from "next/link";

--- a/modules/service/components/UpdateServiceDialog.tsx
+++ b/modules/service/components/UpdateServiceDialog.tsx
@@ -32,7 +32,7 @@ import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 import { Textarea } from "@/components/ui/textarea";
 import { Service, ServiceForm } from "../types/service";
-import { createService } from "../actions/create-service";
+// createService ถูกลบออก — UpdateServiceDialog ใช้แค่ updateService
 import { updateService } from "../actions/update-service";
 
 interface UpdateServiceDialogProps {

--- a/modules/service/components/UpdateServiceVariantDialog.tsx
+++ b/modules/service/components/UpdateServiceVariantDialog.tsx
@@ -61,6 +61,8 @@ export function UpdateServiceVariantDialog({
   });
 
   useEffect(() => {
+    // reset form ทุกครั้งที่ serviceVariant เปลี่ยนแปลง (เช่น เปิด dialog สำหรับ variant อื่น)
+    // `form` ถูกรวมใน deps เพื่อให้ ESLint พอใจ — object นี้มี stable reference จาก useForm
     form.reset({
       petType: serviceVariant.petType,
       size: serviceVariant.size,
@@ -69,7 +71,7 @@ export function UpdateServiceVariantDialog({
       isStartingPriceOnly: serviceVariant.isStartingPriceOnly.toString(),
       durationMinutes: serviceVariant.durationMinutes.toString(),
     });
-  }, [serviceVariant]);
+  }, [serviceVariant, form]);
 
   const onSubmit = async (data: UpdateServiceVariantForm) => {
     try {


### PR DESCRIPTION
Cleanup unused imports and minor fixes across multiple components to reduce lint noise and clarify intent. Removed unused icons, UI helpers, and type imports (replaced with explanatory comments) in several modules, limited type imports in service actions to only what's used, added console.error in listPets for better error visibility, and included the form object in UpdateServiceVariantDialog useEffect deps (with a comment) to ensure proper form reset. Affected files include components/nav-user.tsx, lib/permissions.ts, multiple modules under auth, customer, pet, pet-breed, and service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* แก้ไขการซิงโครไนซ์สถานะแบบฟอร์มในแผนการจัดการบริการ

## Chores
* ลบการนำเข้าไลบรารีและส่วนประกอบที่ไม่ใช้งาน
* เพิ่มการบันทึกข้อผิดพลาดในกระบวนการจัดการสัตว์เลี้ยง

<!-- end of auto-generated comment: release notes by coderabbit.ai -->