### PR TITLE
Add operations module, UI and server actions

### DIFF
--- a/app/(back-office)/appointments/[id]/page.tsx
+++ b/app/(back-office)/appointments/[id]/page.tsx
@@ -6,9 +6,11 @@ import AppointmentStatusManager from "@/modules/appointment/components/Appointme
 import { PET_TYPE_LABELS } from "@/lib/constants/pet-type";
 import { PET_SIZE_LABELS } from "@/lib/constants/service-type";
 
-import BackButton from "@/components/BackButton";
 import { requireStaff } from "@/lib/session";
 import { SiteHeader } from "@/components/site-header";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft } from "lucide-react";
+import Link from "next/link";
 
 type PetWithServices = {
   petId: string;
@@ -46,7 +48,15 @@ export default async function AppointmentDetailPage({
       <SiteHeader title="รายละเอียดการจอง" />
 
       <main className="space-y-6 mx-auto p-6 w-full">
-        <BackButton />
+        <Button
+          variant="outline"
+          asChild
+        >
+          <Link href="/appointments">
+            <ChevronLeft className="mr-2 w-4 h-4" />
+            กลับ
+          </Link>
+        </Button>
         {/* 1. Header & Status Manager */}
         <div className="bg-white shadow-sm p-6 border border-slate-200 rounded-2xl">
           <div className="flex justify-between items-start mb-6 pb-4 border-b">

--- a/app/(back-office)/operations/[appointmentId]/[petId]/page.tsx
+++ b/app/(back-office)/operations/[appointmentId]/[petId]/page.tsx
@@ -1,0 +1,38 @@
+import { getPetOperationDetail } from "@/modules/operation/queries/get-pet-operation-detail";
+import OperationDetailClient from "@/modules/operation/components/OperationDetailClient";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { SiteHeader } from "@/components/site-header";
+import BackButton from "@/components/BackButton";
+import { requireStaff } from "@/lib/session";
+
+interface PageProps {
+  params: Promise<{
+    appointmentId: string;
+    petId: string;
+  }>;
+}
+
+export default async function OperationDetailPage({ params }: PageProps) {
+  await requireStaff();
+
+  const { appointmentId, petId } = await params;
+  const result = await getPetOperationDetail(appointmentId, petId);
+
+  if (!result.success || !result.data) {
+    notFound();
+  }
+
+  return (
+    <>
+      <SiteHeader title="รายละเอียดคิวงาน" />
+      <div className="p-6">
+        <BackButton className="mb-4" />
+        {/* โยนข้อมูลที่ Merge แล้วไปยัง Client Component */}
+        <OperationDetailClient initialData={result.data} />
+      </div>
+    </>
+  );
+}

--- a/app/(back-office)/operations/page.tsx
+++ b/app/(back-office)/operations/page.tsx
@@ -1,0 +1,29 @@
+import { getTodayAppointmentsBoard } from "@/modules/operation/queries/get-today-appointments";
+import DailyAppointmentsBoard from "@/modules/operation/components/DailyAppointmentsBoard";
+import { SiteHeader } from "@/components/site-header";
+import { requireStaff } from "@/lib/session";
+
+export default async function DailyBoardPage() {
+  await requireStaff();
+  
+  const result = await getTodayAppointmentsBoard();
+
+  if (!result.success || !result.data) {
+    return (
+      <div className="p-6 text-red-600">
+        <h2>เกิดข้อผิดพลาดในการดึงข้อมูลคิวงาน</h2>
+        <p>{result.error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <SiteHeader title="คิวงานประจำวัน" />
+      {/* โยน Data จาก Server Action เข้าไปยัง Client Component */}
+      <div className="p-6">
+        <DailyAppointmentsBoard initialAppointments={result.data} />
+      </div>
+    </>
+  );
+}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   LayoutGridIcon,
   CalendarClockIcon,
   ReceiptIcon,
+  ListTodoIcon,
 } from "lucide-react";
 import { authClient } from "@/lib/auth-client";
 import Link from "next/link";
@@ -50,6 +51,11 @@ const data = {
       title: "จัดการนัดหมาย",
       url: "/appointments",
       icon: <CalendarClockIcon />,
+    },
+    {
+      title: "คิวงานประจำวัน",
+      url: "/operations",
+      icon: <ListTodoIcon />,
     },
     {
       title: "POS",

--- a/db/schema/appointment.ts
+++ b/db/schema/appointment.ts
@@ -117,7 +117,7 @@ export const serviceImages = p
     {
       id: p.uuid("id").defaultRandom().primaryKey(),
       imageUrl: p.text("image_url").notNull(),
-      type: serviceImageTypeEnum("type").notNull(),
+      type: serviceImageTypeEnum("type").notNull(), // "BEFORE", "AFTER", "ISSUE"
       // FK ไปยัง appointmentItems
       appointmentItemId: p
         .uuid("appointment_item_id")

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,10 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error("Missing Supabase environment variables");
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/modules/appointment/components/ScheduleCanvas.tsx
+++ b/modules/appointment/components/ScheduleCanvas.tsx
@@ -29,7 +29,7 @@ import { STATUS_CONFIG } from "@/lib/constants/appointment-status";
 const START_HOUR = 9;
 const END_HOUR = 18;
 const TOTAL_HOURS = END_HOUR - START_HOUR;
-const ROW_HEIGHT_PX = 80;
+const ROW_HEIGHT_PX = 100;
 const CANVAS_PADDING_TOP = 16;
 
 const hoursGrid = Array.from(
@@ -56,7 +56,6 @@ const InteractiveStatusSelect = ({
   }, [currentStatus]);
 
   const handleStatusChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    e.preventDefault(); // กันเหนียว แม้ว่า select ส่วนใหญ่จะไม่ trigger link ก็ตาม
     e.stopPropagation();
 
     const newStatus = e.target.value as ScheduleRecord["status"];

--- a/modules/appointment/queries/get-schedule.ts
+++ b/modules/appointment/queries/get-schedule.ts
@@ -5,7 +5,7 @@ import { db } from "@/db";
 import { appointments, appointmentItems } from "@/db/schema"; // นำเข้าตารางของคุณ
 // สมมติว่าคุณมีตารางเหล่านี้ (กรุณาปรับ path ตามจริง)
 import { customers, pets, serviceVariants, services } from "@/db/schema";
-import { and, eq, gte, lte } from "drizzle-orm";
+import { and, eq, gte, lte, not } from "drizzle-orm";
 import { startOfDay, endOfDay, parseISO } from "date-fns";
 import { ScheduleRecord } from "../types/schedule";
 import { ActionResponse } from "@/types/action";
@@ -49,6 +49,7 @@ export async function getScheduleByDate(
         and(
           gte(appointmentItems.startTime, start),
           lte(appointmentItems.startTime, end),
+          not(eq(appointments.status, "CANCELLED")),
         ),
       )
       .orderBy(appointmentItems.startTime);

--- a/modules/operation/actions/create-health-report.ts
+++ b/modules/operation/actions/create-health-report.ts
@@ -1,0 +1,76 @@
+"use server";
+
+import { db } from "@/db";
+import {
+  appointmentItems,
+  healthReports,
+  services,
+  serviceVariants,
+} from "@/db/schema";
+import { requireStaff } from "@/lib/session";
+import { and, eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+export async function addHealthReport(data: {
+  topic: string;
+  description: string;
+  appointmentId: string;
+  petId: string;
+}) {
+  try {
+    const session = await requireStaff({ redirect: false });
+    if (!session) {
+      return {
+        success: false as const,
+        error: "คุณไม่มีสิทธิ์ดำเนินการ",
+      };
+    }
+
+    // 1. ค้นหา ID ของบริการหลัก
+    const mainServiceItems = await db
+      .select({
+        itemId: appointmentItems.id, // เลือกมาแค่ ID เพื่อความรวดเร็ว
+      })
+      .from(appointmentItems) // ตั้งต้นที่ appointmentItems ได้เลย
+      .innerJoin(
+        serviceVariants,
+        eq(appointmentItems.serviceVariantId, serviceVariants.id),
+      )
+      .innerJoin(services, eq(serviceVariants.serviceId, services.id))
+      .where(
+        and(
+          eq(appointmentItems.appointmentId, data.appointmentId),
+          eq(appointmentItems.petId, data.petId),
+          eq(services.serviceType, "MAIN"),
+        ),
+      )
+      .limit(1); // สั่ง Limit 1 เพราะเราต้องการแค่อันเดียว
+
+    // 2. ป้องกันระบบพัง กรณีหาบริการหลักไม่เจอ
+    if (mainServiceItems.length === 0) {
+      return {
+        success: false,
+        error:
+          "ไม่พบรายการบริการหลัก (MAIN) สำหรับการจองนี้ ไม่สามารถบันทึกรายงานได้",
+      };
+    }
+
+    // 3. บันทึกข้อมูล
+    await db.insert(healthReports).values({
+      topic: data.topic,
+      description: data.description,
+      appointmentItemId: mainServiceItems[0].itemId, // ใช้ ID ที่ได้มา
+    });
+
+    // แนะนำให้ใช้ Template Literal เพื่อให้ Revalidate ถูก Path จริงๆ
+    revalidatePath(`/operations/${data.appointmentId}/${data.petId}`);
+
+    return { success: true, data: null };
+  } catch (error) {
+    console.error("addHealthReport error:", error);
+    return {
+      success: false,
+      error: "เกิดข้อผิดพลาด ไม่สามารถบันทึกข้อมูลได้",
+    };
+  }
+}

--- a/modules/operation/actions/delete-health-report.ts
+++ b/modules/operation/actions/delete-health-report.ts
@@ -1,0 +1,41 @@
+"use server";
+
+import { db } from "@/db";
+import { healthReports } from "@/db/schema";
+import { requireStaff } from "@/lib/session";
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+export async function deleteHealthReport(
+  id: string,
+  appointmentId: string,
+  petId: string,
+) {
+  try {
+    const session = await requireStaff({ redirect: false });
+    if (!session) {
+      return {
+        success: false as const,
+        error: "คุณไม่มีสิทธิ์ดำเนินการ",
+      };
+    }
+
+    const result = await db
+      .update(healthReports)
+      .set({ deletedAt: new Date() })
+      .where(eq(healthReports.id, id))
+      .returning({ id: healthReports.id });
+
+    if (result.length === 0) {
+      return { success: false, error: "ไม่พบข้อมูลที่ต้องการลบ" };
+    }
+
+    // รีเฟรชข้อมูลในหน้า Detail หลังจากลบเสร็จ
+    revalidatePath(`/operations/${appointmentId}/${petId}`);
+
+    return { success: true };
+  } catch (error) {
+    console.error("Error deleting health report:", error);
+    return { success: false, error: "เกิดข้อผิดพลาด ไม่สามารถลบข้อมูลได้" };
+  }
+}

--- a/modules/operation/actions/delete-service-image.ts
+++ b/modules/operation/actions/delete-service-image.ts
@@ -24,8 +24,9 @@ export async function deleteServiceImage(
 
     // 1. ดึงชื่อไฟล์ออกมาจาก URL เพื่อนำไปลบใน Storage
     // ตัวอย่าง URL: https://[project].supabase.co/storage/v1/object/public/images/12345.jpg
-    const urlParts = imageUrl.split("/");
-    const fileName = urlParts[urlParts.length - 1];
+    const urlObj = new URL(imageUrl);
+    const pathParts = urlObj.pathname.split("/");
+    const fileName = pathParts[pathParts.length - 1];
 
     if (fileName) {
       // 2. ลบไฟล์ใน Supabase Storage

--- a/modules/operation/actions/delete-service-image.ts
+++ b/modules/operation/actions/delete-service-image.ts
@@ -1,0 +1,53 @@
+"use server";
+
+import { db } from "@/db";
+import { serviceImages } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+import { supabase } from "@/lib/supabase"; // ปรับ path ตามจริง
+import { requireStaff } from "@/lib/session";
+
+export async function deleteServiceImage(
+  imageId: string,
+  imageUrl: string,
+  appointmentId: string,
+  petId: string,
+) {
+  try {
+    const session = await requireStaff({ redirect: false });
+    if (!session) {
+      return {
+        success: false as const,
+        error: "คุณไม่มีสิทธิ์ดำเนินการ",
+      };
+    }
+
+    // 1. ดึงชื่อไฟล์ออกมาจาก URL เพื่อนำไปลบใน Storage
+    // ตัวอย่าง URL: https://[project].supabase.co/storage/v1/object/public/images/12345.jpg
+    const urlParts = imageUrl.split("/");
+    const fileName = urlParts[urlParts.length - 1];
+
+    if (fileName) {
+      // 2. ลบไฟล์ใน Supabase Storage
+      const { error: storageError } = await supabase.storage
+        .from("images") // ระบุชื่อ bucket ให้ถูกต้อง
+        .remove([fileName]);
+
+      if (storageError) {
+        console.error("Storage delete error:", storageError);
+        // ถึงแม้จะลบใน Storage ไม่สำเร็จ (เช่น ไฟล์หายไปแล้ว) เราก็ควรลบใน DB ต่อไป
+      }
+    }
+
+    // 3. ลบ Record ใน Database
+    await db.delete(serviceImages).where(eq(serviceImages.id, imageId));
+
+    // 4. Refresh UI
+    revalidatePath(`/operations/${appointmentId}/${petId}`);
+
+    return { success: true };
+  } catch (error) {
+    console.error("Error deleting service image:", error);
+    return { success: false, error: "เกิดข้อผิดพลาด ไม่สามารถลบรูปภาพได้" };
+  }
+}

--- a/modules/operation/actions/update-health-report.ts
+++ b/modules/operation/actions/update-health-report.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import { db } from "@/db";
+import { healthReports } from "@/db/schema";
+import { requireStaff } from "@/lib/session";
+import { eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+export async function updateHealthReport(data: {
+  id: string;
+  topic: string;
+  description: string;
+  appointmentId: string;
+  petId: string;
+}) {
+  try {
+    const session = await requireStaff({ redirect: false });
+    if (!session) {
+      return {
+        success: false as const,
+        error: "คุณไม่มีสิทธิ์ดำเนินการ",
+      };
+    }
+
+    const result = await db
+      .update(healthReports)
+      .set({
+        topic: data.topic,
+        description: data.description,
+      })
+      .where(eq(healthReports.id, data.id))
+      .returning({ id: healthReports.id });
+
+    if (result.length === 0) {
+      return { success: false, error: "ไม่พบข้อมูลที่ต้องการแก้ไข" };
+    }
+
+    // รีเฟรชข้อมูลในหน้า Detail
+    revalidatePath(`/operations/${data.appointmentId}/${data.petId}`);
+
+    return { success: true };
+  } catch (error) {
+    console.error("updateHealthReport error:", error);
+    return { success: false, error: "เกิดข้อผิดพลาด ไม่สามารถแก้ไขข้อมูลได้" };
+  }
+}

--- a/modules/operation/actions/upload-service-images.ts
+++ b/modules/operation/actions/upload-service-images.ts
@@ -13,16 +13,21 @@ import { revalidatePath } from "next/cache";
 
 export async function uploadServiceImages(data: {
   imageUrls: string[];
-  type: "BEFORE" | "AFTER";
+  type: "BEFORE" | "AFTER" | "ISSUE";
   appointmentId: string;
   petId: string;
 }) {
+  const uploadedFileNames = data.imageUrls
+    .map((url) => url.split("/").pop() || "")
+    .filter(Boolean);
+
   try {
     const session = await requireStaff({ redirect: false });
     if (!session) {
       return {
         success: false as const,
         error: "คุณไม่มีสิทธิ์ดำเนินการ",
+        uploadedFileNames,
       };
     }
 
@@ -46,8 +51,9 @@ export async function uploadServiceImages(data: {
 
     if (mainServiceItems.length === 0) {
       return {
-        success: false,
+        success: false as const,
         error: "ไม่พบรายการบริการหลัก (MAIN) ไม่สามารถบันทึกรูปภาพได้",
+        uploadedFileNames,
       };
     }
 
@@ -68,12 +74,13 @@ export async function uploadServiceImages(data: {
     // 4. รีเฟรชหน้า UI
     revalidatePath(`/operations/${data.appointmentId}/${data.petId}`);
 
-    return { success: true };
+    return { success: true as const, uploadedFileNames };
   } catch (error) {
     console.error("Error adding service images:", error);
     return {
-      success: false,
+      success: false as const,
       error: "เกิดข้อผิดพลาดในการบันทึกรูปภาพลงฐานข้อมูล",
+      uploadedFileNames,
     };
   }
 }

--- a/modules/operation/actions/upload-service-images.ts
+++ b/modules/operation/actions/upload-service-images.ts
@@ -1,0 +1,79 @@
+"use server";
+
+import { db } from "@/db";
+import {
+  appointmentItems,
+  serviceImages,
+  services,
+  serviceVariants,
+} from "@/db/schema";
+import { requireStaff } from "@/lib/session";
+import { and, eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+export async function uploadServiceImages(data: {
+  imageUrls: string[];
+  type: "BEFORE" | "AFTER";
+  appointmentId: string;
+  petId: string;
+}) {
+  try {
+    const session = await requireStaff({ redirect: false });
+    if (!session) {
+      return {
+        success: false as const,
+        error: "คุณไม่มีสิทธิ์ดำเนินการ",
+      };
+    }
+
+    // 1. ค้นหา ID ของบริการหลัก (MAIN)
+    const mainServiceItems = await db
+      .select({ itemId: appointmentItems.id })
+      .from(appointmentItems)
+      .innerJoin(
+        serviceVariants,
+        eq(appointmentItems.serviceVariantId, serviceVariants.id),
+      )
+      .innerJoin(services, eq(serviceVariants.serviceId, services.id))
+      .where(
+        and(
+          eq(appointmentItems.appointmentId, data.appointmentId),
+          eq(appointmentItems.petId, data.petId),
+          eq(services.serviceType, "MAIN"),
+        ),
+      )
+      .limit(1);
+
+    if (mainServiceItems.length === 0) {
+      return {
+        success: false,
+        error: "ไม่พบรายการบริการหลัก (MAIN) ไม่สามารถบันทึกรูปภาพได้",
+      };
+    }
+
+    const appointmentItemId = mainServiceItems[0].itemId;
+
+    // 2. เตรียมข้อมูลสำหรับ Bulk Insert
+    const values = data.imageUrls.map((url) => ({
+      imageUrl: url,
+      type: data.type,
+      appointmentItemId: appointmentItemId,
+    }));
+
+    // 3. บันทึกลงฐานข้อมูล
+    if (values.length > 0) {
+      await db.insert(serviceImages).values(values);
+    }
+
+    // 4. รีเฟรชหน้า UI
+    revalidatePath(`/operations/${data.appointmentId}/${data.petId}`);
+
+    return { success: true };
+  } catch (error) {
+    console.error("Error adding service images:", error);
+    return {
+      success: false,
+      error: "เกิดข้อผิดพลาดในการบันทึกรูปภาพลงฐานข้อมูล",
+    };
+  }
+}

--- a/modules/operation/components/CreateHealthReportDialog.tsx
+++ b/modules/operation/components/CreateHealthReportDialog.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { PlusIcon } from "lucide-react";
+
+import { addHealthReport } from "@/modules/operation/actions/create-health-report";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Separator } from "@/components/ui/separator";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
+
+type HealthReportForm = {
+  topic: string;
+  description: string;
+};
+
+interface Props {
+  appointmentId: string;
+  petId: string;
+}
+
+export default function HealthReportModal({ appointmentId, petId }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const form = useForm<HealthReportForm>({
+    defaultValues: {
+      topic: "",
+      description: "",
+    },
+    mode: "onBlur",
+  });
+
+  const onSubmit = async (data: HealthReportForm) => {
+    try {
+      setServerError(null);
+
+      const result = await addHealthReport({
+        ...data,
+        appointmentId,
+        petId,
+      });
+
+      if (!result.success) {
+        setServerError(result.error || "เกิดข้อผิดพลาด");
+        return;
+      }
+
+      setOpen(false);
+      form.reset();
+      toast.success("บันทึกรายงานสุขภาพสำเร็จ");
+      router.refresh();
+    } catch (error) {
+      console.error("CreateHealthReport Error:", error);
+      setServerError("เกิดข้อผิดพลาดในการบันทึกรายงานสุขภาพ");
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => {
+        if (!value) {
+          form.reset();
+          setServerError(null);
+        }
+        setOpen(value);
+      }}
+    >
+      <form onSubmit={form.handleSubmit(onSubmit)} id="create-health-report">
+        {/* Trigger Button: ปรับ style ให้เหมาะกับ Header ของ Card */}
+        <DialogTrigger asChild className="text-sm cursor-pointer">
+          <Button type="button" size="sm" variant="outline">
+            <PlusIcon className="mr-2 size-3.5" /> เพิ่มรายงาน
+          </Button>
+        </DialogTrigger>
+
+        <DialogContent className="md:max-w-md">
+          <DialogHeader className="px-4 pt-4">
+            <DialogTitle className="font-bold text-lg">
+              เพิ่มรายงานสุขภาพเบื้องต้น
+            </DialogTitle>
+            <DialogDescription>
+              บันทึกความผิดปกติ เห็บหมัด หรือข้อควรระวังสำหรับสัตว์เลี้ยง
+            </DialogDescription>
+            {serverError && (
+              <DialogDescription className="text-destructive">
+                {serverError}
+              </DialogDescription>
+            )}
+          </DialogHeader>
+          <Separator />
+
+          <FieldGroup className="gap-4 px-4 pt-2 pb-3">
+            {/* Topic Field */}
+            <Controller
+              name="topic"
+              control={form.control}
+              rules={{
+                required: "กรุณาระบุหัวข้อ",
+                maxLength: {
+                  value: 100,
+                  message: "หัวข้อไม่เกิน 100 ตัวอักษร",
+                },
+              }}
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel htmlFor={field.name}>
+                    หัวข้อ <span className="text-destructive">*</span>
+                  </FieldLabel>
+                  <Input
+                    {...field}
+                    id={field.name}
+                    aria-invalid={fieldState.invalid}
+                    placeholder="เช่น พบเห็บหมัด, มีแผลที่หูซ้าย..."
+                    autoComplete="off"
+                  />
+                  {fieldState.invalid && (
+                    <FieldError errors={[fieldState.error]} />
+                  )}
+                </Field>
+              )}
+            />
+
+            {/* Description Field */}
+            <Controller
+              name="description"
+              control={form.control}
+              rules={{
+                required: "กรุณาระบุรายละเอียด",
+              }}
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel htmlFor={field.name}>
+                    รายละเอียด <span className="text-destructive">*</span>
+                  </FieldLabel>
+                  <Textarea
+                    {...field}
+                    id={field.name}
+                    aria-invalid={fieldState.invalid}
+                    placeholder="อธิบายรายละเอียดเพิ่มเติม..."
+                    rows={4}
+                    className="resize-none"
+                  />
+                  {fieldState.invalid && (
+                    <FieldError errors={[fieldState.error]} />
+                  )}
+                </Field>
+              )}
+            />
+          </FieldGroup>
+
+          <DialogFooter>
+            <div className="flex justify-end gap-2">
+              <DialogClose asChild>
+                <Button
+                  variant="outline"
+                  className="px-6 py-5 text-sm cursor-pointer"
+                >
+                  ยกเลิก
+                </Button>
+              </DialogClose>
+              <Button
+                type="submit"
+                form="create-health-report"
+                className="px-6 py-5 text-sm cursor-pointer"
+                disabled={form.formState.isSubmitting}
+              >
+                {form.formState.isSubmitting ? "กำลังบันทึก..." : "บันทึก"}
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </form>
+    </Dialog>
+  );
+}

--- a/modules/operation/components/DailyAppointmentsBoard.tsx
+++ b/modules/operation/components/DailyAppointmentsBoard.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useMemo } from "react";
+import { format } from "date-fns";
+import { th } from "date-fns/locale";
+import { Clock, Scissors, User, ChevronRight } from "lucide-react";
+import Link from "next/link";
+
+// shadcn/ui components
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardFooter,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { AppointmentStatusBadge } from "@/components/StatusBadge"; // สมมติว่าคุณมี Component นี้แล้ว
+import { type TodayAppointmentsResult } from "../queries/get-today-appointments";
+
+export type AppointmentStatus =
+  | "PENDING_DEPOSIT"
+  | "PENDING_APPROVAL"
+  | "CONFIRMED"
+  | "CHECKED_IN"
+  | "IN_PROGRESS"
+  | "READY_FOR_PICKUP"
+  | "COMPLETED"
+  | "CANCELLED"
+  | "NO_SHOW";
+
+// กำหนด Type ใหม่สำหรับข้อมูลที่ถูกจัดกลุ่มแล้ว
+type GroupedAppointmentItem = {
+  id: string; // ใช้ ID ของ item แรกสำหรับเป็น Link อ้างอิง
+  appointmentId: string;
+  petId: string;
+  status: AppointmentStatus;
+  startTime: Date;
+  customerName: string;
+  pet: { id: string; name: string; breed: { name: string } };
+  services: string[]; // เก็บรายการบริการทั้งหมดของสัตว์เลี้ยงตัวนี้ในบิลนี้
+};
+
+interface Props {
+  initialAppointments: TodayAppointmentsResult;
+}
+
+export default function DailyAppointmentsBoard({ initialAppointments }: Props) {
+  // จัดกลุ่มข้อมูลด้วย appointmentId และ petId
+  const groupedItems: GroupedAppointmentItem[] = useMemo(() => {
+    const groups = new Map<string, GroupedAppointmentItem>();
+
+    initialAppointments.forEach((app) => {
+      app.items.forEach((item) => {
+        // สร้าง Composite Key เพื่อใช้จัดกลุ่ม
+        const key = `${app.id}-${item.pet.id}`;
+        const serviceName = item.serviceVariant.service.name;
+
+        if (!groups.has(key)) {
+          groups.set(key, {
+            id: item.id,
+            appointmentId: app.id,
+            petId: item.pet.id,
+            status: app.status as AppointmentStatus,
+            startTime: new Date(item.startTime),
+            customerName: app.customer.nickname,
+            pet: item.pet,
+            services: [serviceName], // เริ่มต้น Array บริการ
+          });
+        } else {
+          const existingGroup = groups.get(key)!;
+          // เพิ่มบริการเข้าไปใน Array ถ้ายังไม่มี
+          if (!existingGroup.services.includes(serviceName)) {
+            existingGroup.services.push(serviceName);
+          }
+          // อัปเดต startTime ให้เป็นเวลาที่เช้าที่สุดของกลุ่ม
+          const itemStartTime = new Date(item.startTime);
+          if (itemStartTime < existingGroup.startTime) {
+            existingGroup.startTime = itemStartTime;
+          }
+        }
+      });
+    });
+
+    return Array.from(groups.values());
+  }, [initialAppointments]);
+
+  // กรองตามหมวดหมู่คอลัมน์
+  const pendingItems = groupedItems.filter((i) =>
+    ["PENDING_DEPOSIT", "PENDING_APPROVAL", "CONFIRMED", "CHECKED_IN"].includes(
+      i.status,
+    ),
+  );
+  const inProgressItems = groupedItems.filter(
+    (i) => i.status === "IN_PROGRESS",
+  );
+  const completedItems = groupedItems.filter((i) =>
+    ["READY_FOR_PICKUP", "COMPLETED"].includes(i.status),
+  );
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Summary Header Cards */}
+      <div className="gap-4 grid grid-cols-1 md:grid-cols-3">
+        <SummaryCard
+          title="รอดำเนินการ"
+          count={pendingItems.length}
+          colorText="text-yellow-600"
+        />
+        <SummaryCard
+          title="กำลังทำ"
+          count={inProgressItems.length}
+          colorText="text-blue-600"
+        />
+        <SummaryCard
+          title="เสร็จสิ้น / รอรับกลับ"
+          count={completedItems.length}
+          colorText="text-green-600"
+        />
+      </div>
+
+      {/* Kanban Board Columns */}
+      <div className="items-start gap-6 grid grid-cols-1 md:grid-cols-3">
+        <Column
+          title="รอดำเนินการ"
+          items={pendingItems}
+          borderColor="border-l-yellow-400"
+        />
+        <Column
+          title="กำลังทำ"
+          items={inProgressItems}
+          borderColor="border-l-blue-500"
+        />
+        <Column
+          title="เสร็จสิ้น"
+          items={completedItems}
+          borderColor="border-l-green-500"
+        />
+      </div>
+    </div>
+  );
+}
+
+// --- Sub Components ---
+
+function SummaryCard({
+  title,
+  count,
+  colorText,
+}: {
+  title: string;
+  count: number;
+  colorText: string;
+}) {
+  return (
+    <Card className="shadow-sm">
+      <CardHeader className="pb-2">
+        <CardTitle className="font-medium text-muted-foreground text-sm">
+          {title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className={`text-3xl font-bold ${colorText}`}>{count}</div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Column({
+  title,
+  items,
+  borderColor,
+}: {
+  title: string;
+  items: GroupedAppointmentItem[];
+  borderColor: string;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      {items.map((item) => (
+        <Card
+          key={`${item.appointmentId}-${item.petId}`}
+          className={`shadow-sm border-l-4 ${borderColor}`}
+        >
+          <CardHeader className="p-4 pb-2">
+            <div className="flex justify-between items-start">
+              <div className="space-y-1">
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  {item.pet.name}
+                  <Badge variant="secondary" className="font-normal text-xs">
+                    {item.pet.breed.name}
+                  </Badge>
+                </CardTitle>
+              </div>
+              <AppointmentStatusBadge status={item.status} />
+            </div>
+          </CardHeader>
+
+          <CardContent className="space-y-2 p-4 py-2 text-muted-foreground text-sm">
+            <div className="flex items-center gap-2">
+              <Clock className="w-4 min-w-4 h-4 text-muted-foreground/70" />
+              {format(item.startTime, "HH:mm น.", { locale: th })}
+            </div>
+            <div className="flex items-start gap-2">
+              <Scissors className="mt-0.5 w-4 min-w-4 h-4 text-muted-foreground/70" />
+              {/* Join ชื่อบริการทั้งหมดด้วยเครื่องหมายลูกน้ำ */}
+              <span className="leading-snug">{item.services.join(" + ")}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <User className="w-4 min-w-4 h-4 text-muted-foreground/70" />
+              คุณ{item.customerName}
+            </div>
+          </CardContent>
+
+          <CardFooter className="flex justify-between items-center mt-2 p-4 pt-3 border-t text-muted-foreground text-xs">
+            <span>ID: {item.appointmentId.slice(0, 8).toUpperCase()}</span>
+            <Button
+              asChild
+              variant="ghost"
+              size="sm"
+              className="hover:bg-blue-50 h-8 text-blue-600 hover:text-blue-700"
+            >
+              <Link href={`/operations/${item.appointmentId}/${item.petId}`}>
+                ดูรายละเอียด
+                <ChevronRight className="ml-1 w-4 h-4" />
+              </Link>
+            </Button>
+          </CardFooter>
+        </Card>
+      ))}
+
+      {items.length === 0 && (
+        <div className="bg-muted/20 p-6 border-2 border-dashed rounded-xl text-muted-foreground text-center">
+          ไม่มีรายการ
+        </div>
+      )}
+    </div>
+  );
+}

--- a/modules/operation/components/DeleteHealthReportButton.tsx
+++ b/modules/operation/components/DeleteHealthReportButton.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+import { Trash2Icon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog"; // ปรับ path ให้ตรงกับที่เก็บ ConfirmDialog ของคุณ
+import { deleteHealthReport } from "@/modules/operation/actions/delete-health-report";
+
+interface Props {
+  reportId: string;
+  topic: string;
+  appointmentId: string;
+  petId: string;
+}
+
+export default function DeleteHealthReportButton({
+  reportId,
+  topic,
+  appointmentId,
+  petId,
+}: Props) {
+  const [open, setOpen] = useState(false);
+
+  const handleDelete = async () => {
+    return await deleteHealthReport(reportId, appointmentId, petId);
+  };
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="hover:bg-destructive/10 w-8 h-8 text-muted-foreground hover:text-destructive"
+        onClick={() => setOpen(true)}
+      >
+        <Trash2Icon className="w-4 h-4" />
+      </Button>
+
+      <ConfirmDialog
+        open={open}
+        onOpenChange={setOpen}
+        title="ยืนยันการลบรายงานสุขภาพ"
+        description={`คุณแน่ใจหรือไม่ว่าต้องการลบรายงาน "${topic}"? การกระทำนี้ไม่สามารถย้อนกลับได้`}
+        onConfirm={handleDelete}
+        successMessage="ลบรายงานสุขภาพสำเร็จ"
+        errorMessage="เกิดข้อผิดพลาดในการลบรายงานสุขภาพ"
+      />
+    </>
+  );
+}

--- a/modules/operation/components/DeleteImageButton.tsx
+++ b/modules/operation/components/DeleteImageButton.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import { Trash2Icon } from "lucide-react";
+import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
+import { deleteServiceImage } from "../actions/delete-service-image";
+
+interface Props {
+  imageId: string;
+  imageUrl: string;
+  appointmentId: string;
+  petId: string;
+}
+
+export default function DeleteImageButton({
+  imageId,
+  imageUrl,
+  appointmentId,
+  petId,
+}: Props) {
+  const [open, setOpen] = useState(false);
+
+  const handleDelete = async () => {
+    return await deleteServiceImage(imageId, imageUrl, appointmentId, petId);
+  };
+
+  return (
+    <>
+      {/* ปุ่มลบรูปภาพ (ซ่อนอยู่ จะโผล่ตอน Hover Container ด้านนอก) */}
+      <button
+        onClick={(e) => {
+          e.stopPropagation(); // ป้องกันไม่ให้ทะลุไปเปิด Lightbox
+          setOpen(true);
+        }}
+        className="top-1 right-1 z-10 absolute bg-black/60 hover:bg-destructive opacity-0 group-hover:opacity-100 p-1.5 rounded-full focus:outline-none text-white transition-all"
+        title="ลบรูปภาพ"
+      >
+        <Trash2Icon className="w-3.5 h-3.5" />
+      </button>
+
+      <ConfirmDialog
+        open={open}
+        onOpenChange={setOpen}
+        title="ยืนยันการลบรูปภาพ"
+        description="คุณแน่ใจหรือไม่ว่าต้องการลบรูปภาพนี้? การกระทำนี้จะลบไฟล์ออกจากระบบถาวร"
+        onConfirm={handleDelete}
+        successMessage="ลบรูปภาพสำเร็จ"
+        errorMessage="เกิดข้อผิดพลาดในการลบรูปภาพ"
+      />
+    </>
+  );
+}

--- a/modules/operation/components/EditHealthReportDialog.tsx
+++ b/modules/operation/components/EditHealthReportDialog.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Edit2Icon } from "lucide-react";
+
+import { updateHealthReport } from "../actions/update-health-report";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Separator } from "@/components/ui/separator";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
+import type { HealthReport } from "./OperationDetailClient"; // ปรับ path ให้ดึง interface มาใช้
+
+type HealthReportForm = {
+  topic: string;
+  description: string;
+};
+
+interface Props {
+  report: HealthReport;
+  appointmentId: string;
+  petId: string;
+}
+
+export default function EditHealthReportDialog({
+  report,
+  appointmentId,
+  petId,
+}: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const form = useForm<HealthReportForm>({
+    defaultValues: {
+      topic: report.topic,
+      description: report.description,
+    },
+    mode: "onBlur",
+  });
+
+  const onSubmit = async (data: HealthReportForm) => {
+    try {
+      setServerError(null);
+
+      const result = await updateHealthReport({
+        id: report.id,
+        topic: data.topic,
+        description: data.description,
+        appointmentId,
+        petId,
+      });
+
+      if (!result.success) {
+        setServerError(result.error || "เกิดข้อผิดพลาด");
+        return;
+      }
+
+      setOpen(false);
+      toast.success("แก้ไขรายงานสุขภาพสำเร็จ");
+      router.refresh();
+    } catch (error) {
+      console.error("EditHealthReport Error:", error);
+      setServerError("เกิดข้อผิดพลาดในการแก้ไขรายงานสุขภาพ");
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => {
+        if (!value) {
+          form.reset({ topic: report.topic, description: report.description });
+          setServerError(null);
+        }
+        setOpen(value);
+      }}
+    >
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        id={`edit-health-report-${report.id}`}
+      >
+        <DialogTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="w-8 h-8 text-muted-foreground hover:text-blue-600"
+          >
+            <Edit2Icon className="w-4 h-4" />
+          </Button>
+        </DialogTrigger>
+
+        <DialogContent className="md:max-w-md">
+          <DialogHeader className="px-4 pt-4">
+            <DialogTitle className="font-bold text-lg">
+              แก้ไขรายงานสุขภาพ
+            </DialogTitle>
+            <DialogDescription>
+              ปรับปรุงรายละเอียดความผิดปกติของสัตว์เลี้ยง
+            </DialogDescription>
+            {serverError && (
+              <DialogDescription className="text-destructive">
+                {serverError}
+              </DialogDescription>
+            )}
+          </DialogHeader>
+          <Separator />
+
+          <FieldGroup className="gap-4 px-4 pt-2 pb-3">
+            <Controller
+              name="topic"
+              control={form.control}
+              rules={{
+                required: "กรุณาระบุหัวข้อ",
+                maxLength: {
+                  value: 100,
+                  message: "หัวข้อไม่เกิน 100 ตัวอักษร",
+                },
+              }}
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel htmlFor={field.name}>
+                    หัวข้อ <span className="text-destructive">*</span>
+                  </FieldLabel>
+                  <Input
+                    {...field}
+                    id={field.name}
+                    aria-invalid={fieldState.invalid}
+                    placeholder="เช่น พบเห็บหมัด, มีแผลที่หูซ้าย..."
+                    autoComplete="off"
+                  />
+                  {fieldState.invalid && (
+                    <FieldError errors={[fieldState.error]} />
+                  )}
+                </Field>
+              )}
+            />
+
+            <Controller
+              name="description"
+              control={form.control}
+              rules={{ required: "กรุณาระบุรายละเอียด" }}
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel htmlFor={field.name}>
+                    รายละเอียด <span className="text-destructive">*</span>
+                  </FieldLabel>
+                  <Textarea
+                    {...field}
+                    id={field.name}
+                    aria-invalid={fieldState.invalid}
+                    placeholder="อธิบายรายละเอียดเพิ่มเติม..."
+                    rows={4}
+                    className="resize-none"
+                  />
+                  {fieldState.invalid && (
+                    <FieldError errors={[fieldState.error]} />
+                  )}
+                </Field>
+              )}
+            />
+          </FieldGroup>
+
+          <DialogFooter>
+            <div className="flex justify-end gap-2">
+              <DialogClose asChild>
+                <Button
+                  variant="outline"
+                  className="px-6 py-5 text-sm cursor-pointer"
+                >
+                  ยกเลิก
+                </Button>
+              </DialogClose>
+              <Button
+                type="submit"
+                form={`edit-health-report-${report.id}`}
+                className="px-6 py-5 text-sm cursor-pointer"
+                disabled={form.formState.isSubmitting}
+              >
+                {form.formState.isSubmitting ? "กำลังบันทึก..." : "บันทึก"}
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </form>
+    </Dialog>
+  );
+}

--- a/modules/operation/components/ImageLightbox.tsx
+++ b/modules/operation/components/ImageLightbox.tsx
@@ -35,21 +35,16 @@ export default function ImageLightbox({
         {children}
       </div>
       <Dialog open={open} onOpenChange={setOpen}>
-        {/* 1. ใช้ max-w-none w-full h-full เพื่อให้กรอบ Dialog กางเต็ม 100% ของหน้าจอ
-          2. ใช้ flex justify-center items-center เพื่อดันเนื้อหาข้างในให้อยู่ตรงกลางจอเป๊ะๆ
-        */}
         <DialogContent
           showCloseButton={false}
           className="flex justify-center items-center bg-transparent shadow-none p-0 border-none outline-none w-full max-w-none h-full"
         >
           <DialogTitle className="sr-only">ดูรูปภาพขนาดเต็ม</DialogTitle>
 
-          {/* กล่องนี้มีขนาดตายตัวเพื่อให้ Image แบบ fill ทำงานได้ */}
           <div className="relative flex justify-center items-center w-[95vw] h-[90vh]">
-            {/* ปุ่มกากบาท จะเกาะอยู่ที่มุมขวาบนของรูปภาพเสมอ */}
             <button
               onClick={() => setOpen(false)}
-              className="-top-4 sm:-top-5 -right-4 sm:-right-5 z-[60] absolute bg-black/60 hover:bg-black/90 shadow-2xl p-2 border border-white/20 rounded-full focus:outline-none text-white/90 hover:text-white transition-all"
+              className="-top-4 sm:-top-5 -right-4 sm:-right-5 z-60 absolute bg-black/60 hover:bg-black/90 shadow-2xl p-2 border border-white/20 rounded-full focus:outline-none text-white/90 hover:text-white transition-all"
             >
               <X className="w-5 sm:w-6 h-5 sm:h-6" />
             </button>
@@ -59,6 +54,7 @@ export default function ImageLightbox({
               alt={alt}
               fill
               className="shadow-2xl rounded-lg object-contain"
+              unoptimized
             />
           </div>
         </DialogContent>

--- a/modules/operation/components/ImageLightbox.tsx
+++ b/modules/operation/components/ImageLightbox.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { X } from "lucide-react";
+import Image from "next/image";
+
+interface ImageLightboxProps {
+  src: string;
+  alt?: string;
+  children: React.ReactNode;
+}
+
+export default function ImageLightbox({
+  src,
+  alt = "Image",
+  children,
+}: ImageLightboxProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <div
+        onClick={() => setOpen(true)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setOpen(true);
+          }
+        }}
+        role="button"
+        tabIndex={0}
+        className="hover:opacity-80 w-full h-full transition-opacity cursor-pointer"
+      >
+        {children}
+      </div>
+      <Dialog open={open} onOpenChange={setOpen}>
+        {/* 1. ใช้ max-w-none w-full h-full เพื่อให้กรอบ Dialog กางเต็ม 100% ของหน้าจอ
+          2. ใช้ flex justify-center items-center เพื่อดันเนื้อหาข้างในให้อยู่ตรงกลางจอเป๊ะๆ
+        */}
+        <DialogContent
+          showCloseButton={false}
+          className="flex justify-center items-center bg-transparent shadow-none p-0 border-none outline-none w-full max-w-none h-full"
+        >
+          <DialogTitle className="sr-only">ดูรูปภาพขนาดเต็ม</DialogTitle>
+
+          {/* กล่องนี้มีขนาดตายตัวเพื่อให้ Image แบบ fill ทำงานได้ */}
+          <div className="relative flex justify-center items-center w-[95vw] h-[90vh]">
+            {/* ปุ่มกากบาท จะเกาะอยู่ที่มุมขวาบนของรูปภาพเสมอ */}
+            <button
+              onClick={() => setOpen(false)}
+              className="-top-4 sm:-top-5 -right-4 sm:-right-5 z-[60] absolute bg-black/60 hover:bg-black/90 shadow-2xl p-2 border border-white/20 rounded-full focus:outline-none text-white/90 hover:text-white transition-all"
+            >
+              <X className="w-5 sm:w-6 h-5 sm:h-6" />
+            </button>
+
+            <Image
+              src={src}
+              alt={alt}
+              fill
+              className="shadow-2xl rounded-lg object-contain"
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/modules/operation/components/OperationDetailClient.tsx
+++ b/modules/operation/components/OperationDetailClient.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+import { format } from "date-fns"; // เอา useState ออก
+import { th } from "date-fns/locale";
+import { Camera, ClipboardList, Info, Loader2 } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { AppointmentStatusBadge } from "@/components/StatusBadge";
+import HealthReportModal from "./CreateHealthReportDialog";
+import EditHealthReportDialog from "./EditHealthReportDialog";
+import { useRouter } from "next/navigation";
+import DeleteHealthReportButton from "./DeleteHealthReportButton";
+import UploadImageDialog from "./UploadImageDialog";
+import ImageLightbox from "./ImageLightbox";
+import DeleteImageButton from "./DeleteImageButton";
+import { useTransition } from "react";
+import { updateAppointmentStatus } from "@/modules/appointment/actions/update-appointment";
+import { toast } from "sonner";
+
+// 1. สร้าง Type สำหรับสถานะและข้อมูลย่อย
+export type AppointmentStatus =
+  | "PENDING_DEPOSIT"
+  | "PENDING_APPROVAL"
+  | "CONFIRMED"
+  | "CHECKED_IN"
+  | "IN_PROGRESS"
+  | "READY_FOR_PICKUP"
+  | "COMPLETED"
+  | "CANCELLED"
+  | "NO_SHOW";
+
+export interface ServiceImage {
+  id: string;
+  imageUrl: string;
+  type: "BEFORE" | "AFTER" | "ISSUE";
+  createdAt: string | Date;
+}
+
+export interface HealthReport {
+  id: string;
+  topic: string;
+  description: string;
+  createdAt: string | Date;
+}
+
+// 2. สร้าง Interface หลักสำหรับ initialData
+export interface OperationData {
+  appointmentId: string;
+  petId: string;
+  appointment: {
+    status: AppointmentStatus;
+    customer: {
+      nickname: string;
+    };
+  };
+  pet: {
+    name: string;
+    breed: {
+      name: string;
+    };
+  };
+  startTime: string | Date;
+  services: string[];
+  itemIds: string[]; // เก็บ ID ของ appointmentItems ไว้ใช้อ้างอิง
+  healthReports: HealthReport[];
+  serviceImages: ServiceImage[];
+}
+
+interface OperationDetailClientProps {
+  initialData: OperationData;
+}
+
+export default function OperationDetailClient({
+  initialData: operation, // Destructure และเปลี่ยนชื่อเป็น operation เพื่อให้ไม่ต้องแก้โค้ดด้านล่าง
+}: OperationDetailClientProps) {
+  const router = useRouter();
+
+  // 1. เพิ่ม useTransition สำหรับจัดการ Loading State ของปุ่มเปลี่ยนสถานะ
+  const [isPendingStatus, startTransitionStatus] = useTransition();
+
+  // ไม่ต้องใช้ useState แล้ว
+  // const [operation] = useState<OperationData>(initialData);
+
+  const serviceImages = operation?.serviceImages || [];
+  const healthReports = operation?.healthReports || [];
+
+  const beforeImages = serviceImages.filter((img) => img.type === "BEFORE");
+  const afterImages = serviceImages.filter((img) => img.type === "AFTER");
+
+  // 2. ฟังก์ชันจัดการการคลิกเปลี่ยนสถานะ
+  const handleUpdateStatus = (newStatus: AppointmentStatus) => {
+    startTransitionStatus(async () => {
+      const result = await updateAppointmentStatus(
+        operation.appointmentId,
+        newStatus,
+      );
+
+      if (!result.success) {
+        toast.error(result.error);
+        return;
+      }
+
+      toast.success("อัปเดตสถานะคิวงานสำเร็จ");
+      router.refresh();
+    });
+  };
+
+  const currentStatus = operation.appointment.status;
+
+  return (
+    <div className="items-start gap-6 grid grid-cols-1 lg:grid-cols-3">
+      {/* Sidebar: ข้อมูลสัตว์เลี้ยงและบริการ */}
+      <div className="lg:top-6 lg:sticky space-y-6 lg:col-span-1">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">ข้อมูลบริการ</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex justify-between items-center">
+              <span className="text-muted-foreground">สัตว์เลี้ยง</span>
+              <span className="flex items-center gap-2 font-semibold">
+                {operation.pet.name}
+                <Badge variant="secondary" className="font-normal text-xs">
+                  {operation.pet.breed.name}
+                </Badge>
+              </span>
+            </div>
+            <Separator />
+            <div className="flex justify-between items-center">
+              <span className="text-muted-foreground">เจ้าของ</span>
+              <span className="font-medium">
+                คุณ{operation.appointment.customer.nickname}
+              </span>
+            </div>
+            <Separator />
+            <div className="flex justify-between items-start">
+              <span className="mt-1 text-muted-foreground">บริการ</span>
+              <div className="flex flex-col items-end gap-1">
+                {operation.services?.map((serviceName, idx) => (
+                  <span key={idx} className="font-medium text-sm text-right">
+                    {serviceName}
+                  </span>
+                ))}
+              </div>
+            </div>
+            <Separator />
+            <div className="flex justify-between items-center">
+              <span className="text-muted-foreground">เวลานัดหมาย</span>
+              <span className="font-medium text-sm">
+                {format(
+                  new Date(operation.startTime),
+                  "dd MMM yyyy, HH:mm น.",
+                  { locale: th },
+                )}
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Main Content */}
+      <div className="space-y-6 lg:col-span-2">
+        {/* Section 1: สถานะงาน */}
+        <Card className="pt-0">
+          <CardHeader className="flex flex-row items-center gap-2 space-y-0 bg-muted/30 py-4 border-b">
+            <Info className="w-5 h-5 text-muted-foreground" />
+            <CardTitle>การจัดการสถานะ (บิลหลัก)</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 pt-6">
+            <div className="flex items-center gap-4">
+              <span className="font-medium text-muted-foreground">
+                สถานะปัจจุบัน:
+              </span>
+              <AppointmentStatusBadge status={currentStatus} />
+            </div>
+
+            <div className="flex flex-wrap gap-2 pt-4 border-t">
+              {/* 3. แสดงปุ่มแบบไดนามิก ตามสถานะปัจจุบัน */}
+
+              {currentStatus === "CONFIRMED" && (
+                <Button
+                  onClick={() => handleUpdateStatus("CHECKED_IN")}
+                  disabled={isPendingStatus}
+                  variant="outline"
+                  className="hover:bg-orange-50 border-orange-200 text-orange-700"
+                >
+                  {isPendingStatus ? (
+                    <Loader2 className="mr-2 w-4 h-4 animate-spin" />
+                  ) : null}
+                  เช็คอิน (ถึงร้านแล้ว)
+                </Button>
+              )}
+
+              {currentStatus === "CHECKED_IN" && (
+                <Button
+                  onClick={() => handleUpdateStatus("IN_PROGRESS")}
+                  disabled={isPendingStatus}
+                  variant="outline"
+                  className="hover:bg-blue-50 border-blue-200 text-blue-700"
+                >
+                  {isPendingStatus ? (
+                    <Loader2 className="mr-2 w-4 h-4 animate-spin" />
+                  ) : null}
+                  เริ่มให้บริการ
+                </Button>
+              )}
+
+              {currentStatus === "IN_PROGRESS" && (
+                <Button
+                  onClick={() => handleUpdateStatus("READY_FOR_PICKUP")}
+                  disabled={isPendingStatus}
+                  variant="outline"
+                  className="hover:bg-teal-50 border-teal-200 text-teal-700"
+                >
+                  {isPendingStatus ? (
+                    <Loader2 className="mr-2 w-4 h-4 animate-spin" />
+                  ) : null}
+                  รอรับกลับ
+                </Button>
+              )}
+
+
+
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Section 2: รูปภาพ */}
+        <Card className="pt-0">
+          <CardHeader className="flex flex-row justify-between items-center space-y-0 bg-muted/30 py-4 border-b">
+            <div className="flex items-center gap-2">
+              <Camera className="w-5 h-5 text-muted-foreground" />
+              <CardTitle>รูปภาพก่อน - หลัง ({serviceImages.length})</CardTitle>
+            </div>
+            {/* เรียกใช้งาน UploadImageDialog */}
+            <UploadImageDialog
+              appointmentId={operation.appointmentId}
+              petId={operation.petId}
+            />
+          </CardHeader>
+          <CardContent className="space-y-6 pt-6">
+            {/* Before Images */}
+            <div>
+              <h3 className="mb-3 font-medium text-muted-foreground text-sm">
+                ก่อนรับบริการ (Before)
+              </h3>
+              {beforeImages.length > 0 ? (
+                <div className="gap-4 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4">
+                  {beforeImages.map((img) => (
+                    // เพิ่มคลาส group ตรงนี้
+                    <div
+                      key={img.id}
+                      className="group relative bg-muted rounded-md aspect-square overflow-hidden"
+                    >
+                      <ImageLightbox src={img.imageUrl} alt="Before">
+                        <img
+                          src={img.imageUrl}
+                          alt="Before"
+                          className="w-full h-full object-cover"
+                        />
+                      </ImageLightbox>
+
+                      {/* วางปุ่มลบรูปภาพ ตรงนี้ */}
+                      <DeleteImageButton
+                        imageId={img.id}
+                        imageUrl={img.imageUrl}
+                        appointmentId={operation.appointmentId}
+                        petId={operation.petId}
+                      />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="bg-muted/20 p-4 border border-dashed rounded text-muted-foreground text-sm text-center">
+                  ยังไม่มีรูปภาพ
+                </p>
+              )}
+            </div>
+
+            {/* After Images */}
+            <div>
+              <h3 className="mb-3 font-medium text-muted-foreground text-sm">
+                หลังรับบริการ (After)
+              </h3>
+              {afterImages.length > 0 ? (
+                <div className="gap-4 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4">
+                  {afterImages.map((img) => (
+                    // เพิ่มคลาส group ตรงนี้
+                    <div
+                      key={img.id}
+                      className="group relative bg-muted rounded-md aspect-square overflow-hidden"
+                    >
+                      <ImageLightbox src={img.imageUrl} alt="After">
+                        <img
+                          src={img.imageUrl}
+                          alt="After"
+                          className="w-full h-full object-cover"
+                        />
+                      </ImageLightbox>
+
+                      {/* วางปุ่มลบรูปภาพ ตรงนี้ */}
+                      <DeleteImageButton
+                        imageId={img.id}
+                        imageUrl={img.imageUrl}
+                        appointmentId={operation.appointmentId}
+                        petId={operation.petId}
+                      />
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="bg-muted/20 p-4 border border-dashed rounded text-muted-foreground text-sm text-center">
+                  ยังไม่มีรูปภาพ
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Section 3: รายงานสุขภาพ */}
+        <Card className="pt-0">
+          <CardHeader className="flex flex-row justify-between items-center space-y-0 bg-muted/30 py-4 border-b">
+            <div className="flex items-center gap-2">
+              <ClipboardList className="w-5 h-5 text-muted-foreground" />
+              <CardTitle>
+                รายงานสุขภาพเบื้องต้น ({healthReports.length})
+              </CardTitle>
+            </div>
+
+            <HealthReportModal
+              appointmentId={operation.appointmentId}
+              petId={operation.petId}
+            />
+          </CardHeader>
+          <CardContent className="pt-6">
+            {healthReports.length > 0 ? (
+              <div className="space-y-4">
+                {healthReports.map((report) => (
+                  <div
+                    key={report.id}
+                    className="group bg-gray-50/50 p-4 border rounded-lg"
+                  >
+                    <div className="flex justify-between items-start mb-2">
+                      <h4 className="font-semibold text-gray-900">
+                        {report.topic}
+                      </h4>
+                      <div className="flex items-center gap-1">
+                        <span className="mr-2 text-muted-foreground text-xs">
+                          {format(new Date(report.createdAt), "dd MMM yyyy", {
+                            locale: th,
+                          })}
+                        </span>
+
+                        <EditHealthReportDialog
+                          report={report}
+                          appointmentId={operation.appointmentId}
+                          petId={operation.petId}
+                        />
+
+                        {/* เพิ่มปุ่มลบ ตรงนี้ */}
+                        <DeleteHealthReportButton
+                          reportId={report.id}
+                          topic={report.topic}
+                          appointmentId={operation.appointmentId}
+                          petId={operation.petId}
+                        />
+                      </div>
+                    </div>
+                    <p className="text-gray-700 text-sm">
+                      {report.description}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="p-8 border-2 border-dashed rounded-lg text-muted-foreground text-sm text-center">
+                ยังไม่มีการบันทึกรายงานสุขภาพ
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/modules/operation/components/UploadImageDialog.tsx
+++ b/modules/operation/components/UploadImageDialog.tsx
@@ -1,0 +1,320 @@
+"use client";
+
+import { useState } from "react";
+import { Controller, useForm } from "react-hook-form";
+import { PlusIcon, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+
+import { supabase } from "@/lib/supabase"; // ปรับ path ตามโปรเจกต์ของคุณ
+import { uploadServiceImages } from "../actions/upload-service-images"; // ปรับ path ตามโปรเจกต์ของคุณ
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from "@/components/ui/field";
+
+// 1. เปลี่ยนจากการเก็บ URL เป็นการเก็บ File Object ของจริง
+type UploadImageForm = {
+  type: "BEFORE" | "AFTER" | "ISSUE";
+  imageFiles: File[];
+};
+
+interface Props {
+  appointmentId: string;
+  petId: string;
+}
+
+export default function UploadImageDialog({ appointmentId, petId }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [isUploading, setIsUploading] = useState(false); // ใช้ตอนกด Submit
+  const [previews, setPreviews] = useState<{ file: File; url: string }[]>([]); // เก็บจับคู่ File กับ Preview URL
+  const [serverError, setServerError] = useState<string | null>(null);
+
+  const form = useForm<UploadImageForm>({
+    defaultValues: {
+      type: "BEFORE",
+      imageFiles: [],
+    },
+    mode: "onBlur",
+  });
+
+  const resetState = () => {
+    previews.forEach((p) => URL.revokeObjectURL(p.url)); // คืน Memory
+    form.reset({ type: "BEFORE", imageFiles: [] });
+    setPreviews([]);
+    setServerError(null);
+  };
+
+  // 2. แค่เก็บไฟล์และสร้าง Preview (ยังไม่อัปโหลด)
+  const handleSelectFiles = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+
+    const newFiles = Array.from(files);
+    const newPreviews = newFiles.map((file) => ({
+      file,
+      url: URL.createObjectURL(file),
+    }));
+
+    // เพิ่มไฟล์ใหม่ต่อท้ายไฟล์เดิมใน State
+    const currentFiles = form.getValues("imageFiles");
+    form.setValue("imageFiles", [...currentFiles, ...newFiles], {
+      shouldValidate: true,
+    });
+
+    setPreviews((prev) => [...prev, ...newPreviews]);
+    e.target.value = ""; // เคลียร์ input เพื่อให้เลือกไฟล์เดิมซ้ำได้
+  };
+
+  // 3. ทำการลบไฟล์ออกจาก Preview และ Form State (ถ้าผู้ใช้เปลี่ยนใจไม่อยากอัปรูปนี้)
+  const handleRemoveFile = (indexToRemove: number) => {
+    const currentFiles = form.getValues("imageFiles");
+
+    // ลบไฟล์ออกจาก Form
+    const newFiles = currentFiles.filter((_, i) => i !== indexToRemove);
+    form.setValue("imageFiles", newFiles, { shouldValidate: true });
+
+    // ลบ Preview และคืน Memory
+    setPreviews((prev) => {
+      const newPreviews = [...prev];
+      URL.revokeObjectURL(newPreviews[indexToRemove].url);
+      newPreviews.splice(indexToRemove, 1);
+      return newPreviews;
+    });
+  };
+
+  // 4. อัปโหลดขึ้น Supabase และบันทึกลง Database ตรงนี้
+  const onSubmit = async (data: UploadImageForm) => {
+    if (data.imageFiles.length === 0) {
+      setServerError("กรุณาอัปโหลดอย่างน้อย 1 รูปภาพ");
+      return;
+    }
+
+    try {
+      setIsUploading(true);
+      setServerError(null);
+
+      const uploadedFileNames: string[] = [];
+
+      // วนลูปอัปโหลดแบบขนาน (Parallel Uploads)
+      const uploadPromises = data.imageFiles.map(async (file) => {
+        const fileExt = file.name.split(".").pop();
+        const fileName = `${appointmentId}-${Date.now()}-${Math.random()
+          .toString(36)
+          .substring(2)}.${fileExt}`;
+
+        const { error: uploadError } = await supabase.storage
+          .from("images")
+          .upload(fileName, file);
+
+        if (uploadError) throw uploadError;
+
+        uploadedFileNames.push(fileName);
+
+        const { data: publicUrlData } = supabase.storage
+          .from("images")
+          .getPublicUrl(fileName);
+
+        return publicUrlData.publicUrl;
+      });
+
+      let uploadedUrls: string[] = [];
+      try {
+        uploadedUrls = await Promise.all(uploadPromises);
+      } catch (uploadError) {
+        // หากมีไฟล์ใดอัปโหลดไม่สำเร็จ ให้ลบไฟล์ที่อัปโหลดไปแล้วออกเพื่อป้องกันไฟล์ค้าง (orphaned uploads)
+        if (uploadedFileNames.length > 0) {
+          await supabase.storage.from("images").remove(uploadedFileNames);
+        }
+        throw uploadError;
+      }
+
+      // ส่ง URL ทั้งหมดให้ Server Action
+      const result = await uploadServiceImages({
+        imageUrls: uploadedUrls,
+        type: data.type,
+        appointmentId,
+        petId,
+      });
+
+      if (!result.success) {
+        setServerError(result.error || "เกิดข้อผิดพลาดในการบันทึกข้อมูล");
+        return;
+      }
+
+      setOpen(false);
+      resetState();
+      toast.success("บันทึกรูปภาพสำเร็จ");
+      router.refresh();
+    } catch (error) {
+      console.error("Submit Images Error:", error);
+      setServerError("เกิดข้อผิดพลาดขณะอัปโหลดไฟล์ไปที่ Server");
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => {
+        if (!value) resetState();
+        setOpen(value);
+      }}
+    >
+      <form onSubmit={form.handleSubmit(onSubmit)} id="upload-image-form">
+        <DialogTrigger asChild className="text-sm cursor-pointer">
+          <Button type="button" size="sm" variant="outline">
+            <PlusIcon className="mr-2 size-3.5" /> เพิ่มรูปภาพ
+          </Button>
+        </DialogTrigger>
+
+        <DialogContent className="md:max-w-lg">
+          <DialogHeader className="px-4 pt-4">
+            <DialogTitle className="font-bold text-lg">
+              อัปโหลดรูปภาพ
+            </DialogTitle>
+            <DialogDescription>
+              เพิ่มรูปภาพก่อนและหลังการให้บริการ (สามารถเลือกได้หลายไฟล์)
+            </DialogDescription>
+            {serverError && (
+              <DialogDescription className="mt-2 font-medium text-destructive">
+                {serverError}
+              </DialogDescription>
+            )}
+          </DialogHeader>
+          <Separator />
+
+          <FieldGroup className="gap-4 px-4 pt-2 pb-3">
+            <Controller
+              name="type"
+              control={form.control}
+              rules={{ required: "กรุณาเลือกประเภท" }}
+              render={({ field, fieldState }) => (
+                <Field data-invalid={fieldState.invalid}>
+                  <FieldLabel htmlFor={field.name}>
+                    ประเภท <span className="text-destructive">*</span>
+                  </FieldLabel>
+                  <Select value={field.value} onValueChange={field.onChange}>
+                    <SelectTrigger id={field.name}>
+                      <SelectValue placeholder="เลือกประเภท" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="BEFORE">
+                        ก่อนรับบริการ (Before)
+                      </SelectItem>
+                      <SelectItem value="AFTER">
+                        หลังรับบริการ (After)
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  {fieldState.invalid && (
+                    <FieldError errors={[fieldState.error]} />
+                  )}
+                </Field>
+              )}
+            />
+
+            <Field>
+              <FieldLabel>
+                เลือกรูปภาพ <span className="text-destructive">*</span>
+              </FieldLabel>
+              <Input
+                type="file"
+                multiple
+                accept="image/png, image/jpeg, image/webp"
+                onChange={handleSelectFiles}
+                disabled={isUploading || form.formState.isSubmitting}
+                className="cursor-pointer"
+              />
+            </Field>
+
+            {/* แสดง Preview พร้อมปุ่มกากบาทลบรูป */}
+            {previews.length > 0 && (
+              <div className="space-y-2 mt-2">
+                <FieldLabel>
+                  ตัวอย่างรูปภาพที่จะอัปโหลด ({previews.length} รูป)
+                </FieldLabel>
+                <div className="flex flex-wrap gap-2 bg-muted/30 p-3 border rounded-lg">
+                  {previews.map((preview, i) => (
+                    <div
+                      key={i}
+                      className="group relative shadow-sm border rounded-md w-20 h-20 overflow-hidden"
+                    >
+                      <img
+                        src={preview.url}
+                        alt="Preview"
+                        className="w-full h-full object-cover"
+                      />
+                      {/* ปุ่มกากบาทเพื่อลบรูปที่ไม่ต้องการ */}
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveFile(i)}
+                        className="top-1 right-1 absolute bg-black/50 hover:bg-destructive opacity-0 group-hover:opacity-100 p-1 rounded-full text-white transition-opacity"
+                      >
+                        <PlusIcon className="w-3 h-3 rotate-45" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </FieldGroup>
+
+          <DialogFooter>
+            <div className="flex justify-end gap-2">
+              <DialogClose asChild>
+                <Button
+                  variant="outline"
+                  className="px-6 py-5 text-sm cursor-pointer"
+                  disabled={isUploading}
+                >
+                  ยกเลิก
+                </Button>
+              </DialogClose>
+              <Button
+                type="submit"
+                form="upload-image-form"
+                className="px-6 py-5 text-sm cursor-pointer"
+                disabled={isUploading || previews.length === 0}
+              >
+                {isUploading ? (
+                  <>
+                    <Loader2 className="mr-2 w-4 h-4 animate-spin" />{" "}
+                    กำลังอัปโหลด...
+                  </>
+                ) : (
+                  "อัปโหลดและบันทึก"
+                )}
+              </Button>
+            </div>
+          </DialogFooter>
+        </DialogContent>
+      </form>
+    </Dialog>
+  );
+}

--- a/modules/operation/components/UploadImageDialog.tsx
+++ b/modules/operation/components/UploadImageDialog.tsx
@@ -162,6 +162,10 @@ export default function UploadImageDialog({ appointmentId, petId }: Props) {
       });
 
       if (!result.success) {
+        // หากบันทึกลงฐานข้อมูลไม่สำเร็จ ให้ลบไฟล์ที่เพิ่งอัปโหลดขึ้น Supabase ออก
+        if (result.uploadedFileNames && result.uploadedFileNames.length > 0) {
+          await supabase.storage.from("images").remove(result.uploadedFileNames);
+        }
         setServerError(result.error || "เกิดข้อผิดพลาดในการบันทึกข้อมูล");
         return;
       }

--- a/modules/operation/queries/get-pet-operation-detail.ts
+++ b/modules/operation/queries/get-pet-operation-detail.ts
@@ -1,0 +1,78 @@
+"use server";
+
+import { db } from "@/db";
+import { appointmentItems } from "@/db/schema";
+import { requireStaff } from "@/lib/session";
+import { eq, and } from "drizzle-orm";
+
+export async function getPetOperationDetail(
+  appointmentId: string,
+  petId: string,
+) {
+  try {
+    const session = await requireStaff({ redirect: false });
+    if (!session) {
+      return {
+        success: false as const,
+        error: "คุณไม่มีสิทธิ์เข้าถึงข้อมูลการรับบริการ",
+      };
+    }
+
+    // ดึง Items ทั้งหมดของสัตว์เลี้ยงตัวนี้ ในการจองครั้งนี้
+    const items = await db.query.appointmentItems.findMany({
+      where: and(
+        eq(appointmentItems.appointmentId, appointmentId),
+        eq(appointmentItems.petId, petId),
+      ),
+      with: {
+        appointment: {
+          with: { customer: true },
+        },
+        pet: {
+          with: { breed: true },
+        },
+        serviceVariant: {
+          with: { service: true },
+        },
+        healthReports: {
+          where: (reports, { isNull }) => isNull(reports.deletedAt),
+          orderBy: (reports, { desc }) => [desc(reports.createdAt)],
+        },
+        serviceImages: {
+          orderBy: (images, { desc }) => [desc(images.createdAt)],
+        },
+      },
+    });
+
+    if (!items || items.length === 0) {
+      return { success: false, error: "ไม่พบข้อมูลการรับบริการ" };
+    }
+
+    // ยุบรวมข้อมูล (Merge) เนื่องจากมีหลาย item (เช่น อาบน้ำ, ตัดขน)
+    // แต่ข้อมูลลูกค้า, สัตว์เลี้ยง และการจองหลัก จะเหมือนกันหมดในทุก item
+    const mergedData = {
+      appointmentId,
+      petId,
+      appointment: items[0].appointment,
+      pet: items[0].pet,
+      // รวมเวลาที่เริ่มเร็วที่สุด
+      startTime: items.reduce((earliest, current) =>
+        new Date(current.startTime) < new Date(earliest.startTime)
+          ? current
+          : earliest,
+      ).startTime,
+      // รวมชื่อบริการทั้งหมด
+      services: items.map((item) => item.serviceVariant.service.name),
+      // Map รายการ items เอาไว้ใช้อ้างอิงตอนสร้าง Health Report/Image
+      itemIds: items.map((item) => item.id),
+      // นำรูปภาพและรายงานมารวมกันใน Array เดียว
+      healthReports: items.flatMap((item) => item.healthReports),
+      serviceImages: items.flatMap((item) => item.serviceImages),
+    };
+
+    return { success: true, data: mergedData };
+  } catch (error) {
+    console.error("getPetOperationDetail error:", error);
+    return { success: false, error: "เกิดข้อผิดพลาดในการดึงข้อมูล" };
+  }
+}

--- a/modules/operation/queries/get-today-appointments.ts
+++ b/modules/operation/queries/get-today-appointments.ts
@@ -1,0 +1,60 @@
+"use server";
+
+import { db } from "@/db";
+import { appointments } from "@/db/schema";
+import { eq, and, gte, lt, notInArray } from "drizzle-orm";
+import { startOfDay, endOfDay } from "date-fns";
+import { requireStaff } from "@/lib/session";
+
+export async function getTodayAppointmentsBoard() {
+  try {
+    const session = await requireStaff({ redirect: false });
+    if (!session) {
+      return {
+        success: false as const,
+        error: "คุณไม่มีสิทธิ์เข้าถึงข้อมูลตารางงานประจำวัน",
+      };
+    }
+
+    const today = new Date();
+    const start = startOfDay(today);
+    const end = endOfDay(today);
+
+    const data = await db.query.appointments.findMany({
+      where: and(
+        gte(appointments.appointmentDate, start),
+        lt(appointments.appointmentDate, end),
+        // ตัดสถานะที่ไม่ใช่ Operation ของวันนี้ออกไป
+        notInArray(appointments.status, [
+          "CANCELLED",
+          "NO_SHOW",
+          "PENDING_DEPOSIT",
+          "PENDING_APPROVAL",
+        ]),
+      ),
+      with: {
+        customer: true,
+        items: {
+          with: {
+            pet: { with: { breed: true } },
+            serviceVariant: { with: { service: true } },
+          },
+        },
+      },
+      orderBy: (appointments, { asc }) => [asc(appointments.appointmentDate)],
+    });
+
+    return { success: true as const, data };
+  } catch (error) {
+    console.error("getTodayAppointmentsBoard error:", error);
+    return {
+      success: false as const,
+      error: "เกิดข้อผิดพลาดในการดึงข้อมูลตารางงานประจำวัน",
+      data: null,
+    };
+  }
+}
+
+export type TodayAppointmentsResult = NonNullable<
+  Awaited<ReturnType<typeof getTodayAppointmentsBoard>>["data"]
+>;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**.supabase.co",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@supabase/supabase-js": "^2.104.1",
     "@tanstack/react-table": "^8.21.3",
     "better-auth": "^1.5.6",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
+      '@supabase/supabase-js':
+        specifier: ^2.104.1
+        version: 2.104.1
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1968,6 +1971,33 @@ packages:
   '@standard-schema/utils@0.3.0':
     resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
+  '@supabase/auth-js@2.104.1':
+    resolution: {integrity: sha512-pqFnDKekq1isqlqnzqzyJ3mzmho+o+FjfVTqhKY3PFlwj2anx3OPznO1kbo1ZEwD8zg1r4EAFf/7pplLyX0ocQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.104.1':
+    resolution: {integrity: sha512-JjAH4JN9rZzxh4plQnILPrQZXAG6ccoRS6z9hQAGmXpRSwJA+7CWbsDV2R82I8MROlGDsjqj1Ot/cWpTfdf6xg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.0':
+    resolution: {integrity: sha512-RHSx8bHS02xwfHdAbX5Lpbo6PXbgyf7lTaXTlwtFDPwOIw64NnVRwFAXGojHhjtVYI+PEPNSWwkL90f4agN3bw==}
+
+  '@supabase/postgrest-js@2.104.1':
+    resolution: {integrity: sha512-RqlLpvgXsjcc27fLyHNGm3zN0KDWXbkdTdaFtaEdX83RsTEqH7BAmshH7zoUMml5lL04naUeRjS3B81O6jZcJw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.104.1':
+    resolution: {integrity: sha512-dVJHhFB2ErBd0/2qE9G8CedCrGoAtBfL9Q4zbSMXO7b1Cpld916ljSiX21mURUqijPf1WoPQG4Bp/averUzk/g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.104.1':
+    resolution: {integrity: sha512-2bQaLbkRshctkUVuqamwYZDEd+0cGSc9DY9sjh92DcA5hu1F/1AP8p6gxGr76sgdK9Ngi0rh+2Kdh+uC4hcnGA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.104.1':
+    resolution: {integrity: sha512-E0H/CtVmaGjiAy+ieZ5ZB/1EqxXcGdaFaAc23AE5zaYfz6NtCNDcmaEdoGPYMPFH5pE6drGG6e3ljPmkFoGVxQ==}
+    engines: {node: '>=20.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -2134,6 +2164,9 @@ packages:
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.58.0':
     resolution: {integrity: sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==}
@@ -3374,6 +3407,10 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -4753,6 +4790,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
@@ -6470,6 +6519,46 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
+  '@supabase/auth-js@2.104.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.104.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.0': {}
+
+  '@supabase/postgrest-js@2.104.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.104.1':
+    dependencies:
+      '@supabase/phoenix': 0.4.0
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.104.1':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.104.1':
+    dependencies:
+      '@supabase/auth-js': 2.104.1
+      '@supabase/functions-js': 2.104.1
+      '@supabase/postgrest-js': 2.104.1
+      '@supabase/realtime-js': 2.104.1
+      '@supabase/storage-js': 2.104.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -6615,6 +6704,10 @@ snapshots:
   '@types/use-sync-external-store@0.0.6': {}
 
   '@types/validate-npm-package-name@4.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.39
 
   '@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -7964,6 +8057,8 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@8.0.1: {}
+
+  iceberg-js@0.8.1: {}
 
   iconv-lite@0.7.2:
     dependencies:
@@ -9506,6 +9601,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
 
   wsl-utils@0.3.1:
     dependencies:


### PR DESCRIPTION
Introduce a new Operations feature: add /operations (daily board) and /operations/[appointmentId]/[petId] pages plus a set of client components (DailyAppointmentsBoard, OperationDetailClient, ImageLightbox, Create/Edit/Delete health report dialogs, Upload/Delete image dialogs/buttons). Implement server actions for health reports and service images (create, update, delete, upload) with requireStaff checks and revalidatePath to refresh pages. Add a Supabase client (lib/supabase) and hook delete-service-image to storage removal. Misc UI and query tweaks: add Operations link to app sidebar, replace BackButton in appointment detail with a Button+Link, increase ScheduleCanvas row height, and filter out CANCELLED appointments in the schedule query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * เพิ่มหน้าคิวงานประจำวัน พร้อมเมนูเชื่อมโยง, หน้าแสดงรายละเอียดการรักษา และปุ่มย้อนกลับใหม่
  * เพิ่ม UI ดู/อัพโหลด/ลบรูปภาพบริการ (lightbox, อัพโหลดหลายรูป) และจัดการรายงานสุขภาพ (สร้าง/แก้ไข/ลบ)
* **Bug Fixes**
  * กรองไม่แสดงนัดหมายที่ยกเลิกในตารางเวลา
* **Chores**
  * รองรับการโหลดรูปภาพจาก Supabase และตั้งค่าการแสดงภาพระยะไกล
<!-- end of auto-generated comment: release notes by coderabbit.ai -->