### PR TITLE
Increase row height and exclude NO_SHOW status

### DIFF
--- a/modules/appointment/components/ScheduleCanvas.tsx
+++ b/modules/appointment/components/ScheduleCanvas.tsx
@@ -30,7 +30,7 @@ import { STATUS_CONFIG } from "@/lib/constants/appointment-status";
 const START_HOUR = 9;
 const END_HOUR = 18;
 const TOTAL_HOURS = END_HOUR - START_HOUR;
-const ROW_HEIGHT_PX = 100;
+const ROW_HEIGHT_PX = 120;
 const CANVAS_PADDING_TOP = 16;
 
 const hoursGrid = Array.from(

--- a/modules/appointment/queries/get-schedule.ts
+++ b/modules/appointment/queries/get-schedule.ts
@@ -5,7 +5,7 @@ import { db } from "@/db";
 import { appointments, appointmentItems } from "@/db/schema"; // นำเข้าตารางของคุณ
 // สมมติว่าคุณมีตารางเหล่านี้ (กรุณาปรับ path ตามจริง)
 import { customers, pets, serviceVariants, services } from "@/db/schema";
-import { and, eq, gte, lte, not } from "drizzle-orm";
+import { and, eq, gte, lte, not, notInArray } from "drizzle-orm";
 import { startOfDay, endOfDay, parseISO } from "date-fns";
 import { ScheduleRecord } from "../types/schedule";
 import { ActionResponse } from "@/types/action";
@@ -50,7 +50,7 @@ export async function getScheduleByDate(
         and(
           gte(appointmentItems.startTime, start),
           lte(appointmentItems.startTime, end),
-          not(eq(appointments.status, "CANCELLED")),
+          notInArray(appointments.status, ["CANCELLED", "NO_SHOW"]),
         ),
       )
       .orderBy(appointmentItems.startTime);


### PR DESCRIPTION
Adjust UI spacing by increasing ROW_HEIGHT_PX from 100 to 120 to provide more vertical room for appointment items. Update getScheduleByDate to filter out NO_SHOW in addition to CANCELLED by importing and using drizzle-orm's notInArray helper, ensuring NO_SHOW appointments are excluded from the returned schedule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * ปรับปรุงการกรองข้อมูลตารางนัดหมาย เพื่อยกเลิกการแสดงนัดหมายที่ถูกยกเลิกหรือไม่เข้าร่วม

* **Style**
  * ปรับปรุงการจัดวางและระยะห่างของแถวในตารางตั้งเวลาให้เหมาะสมยิ่งขึ้น

<!-- end of auto-generated comment: release notes by coderabbit.ai -->