### PR TITLE
Add back-office dashboard and components

### DIFF
--- a/app/(back-office)/dashboard/page.tsx
+++ b/app/(back-office)/dashboard/page.tsx
@@ -1,0 +1,92 @@
+import { Metadata } from "next";
+import { Suspense } from "react";
+import { requireOwner } from "@/lib/session";
+import { SiteHeader } from "@/components/site-header";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// queries
+import { getSalesSummary } from "@/modules/dashboard/queries/get-sales-summary";
+import { getAppointmentSummary } from "@/modules/dashboard/queries/get-appointment-summary";
+import { getPopularServices } from "@/modules/dashboard/queries/get-popular-services";
+import { getReviewSummary } from "@/modules/dashboard/queries/get-review-summary";
+import { getFinanceChartData } from "@/modules/dashboard/queries/get-finance-chart-data";
+
+// components
+import { DashboardPeriodFilter } from "@/modules/dashboard/components/DashboardPeriodFilter";
+import { SalesOverviewCard } from "@/modules/dashboard/components/SalesOverviewCard";
+import { AppointmentSummaryCard } from "@/modules/dashboard/components/AppointmentSummaryCard";
+import { PopularServicesCard } from "@/modules/dashboard/components/PopularServicesCard";
+import { ReviewSummaryCard } from "@/modules/dashboard/components/ReviewSummaryCard";
+import { FinanceOverviewChart } from "@/modules/dashboard/components/FinanceOverviewChart";
+
+import { DashboardPeriod } from "@/modules/dashboard/types/dashboard";
+
+export const metadata: Metadata = {
+  title: "Dashboard",
+  description: "ภาพรวมธุรกิจ — ยอดขาย การจองคิว บริการยอดนิยม รีวิว และการเงิน",
+};
+
+// ===================================================
+// DashboardPage — Server Component
+// ===================================================
+// ดึงข้อมูลทั้ง 5 sections แบบ parallel ผ่าน Promise.all
+// เพื่อลด latency โดยรวม
+// ===================================================
+
+export default async function DashboardPage(props: {
+  searchParams: Promise<{ period?: string }>;
+}) {
+  // ตรวจสอบสิทธิ์: เฉพาะ owner เท่านั้น
+  await requireOwner();
+
+  const searchParams = await props.searchParams;
+
+  // กำหนด period จาก URL หรือ default = MONTHLY
+  const allowedPeriods: DashboardPeriod[] = ["DAILY", "MONTHLY", "YEARLY"];
+  const period: DashboardPeriod = allowedPeriods.includes(
+    searchParams.period as DashboardPeriod,
+  )
+    ? (searchParams.period as DashboardPeriod)
+    : "MONTHLY";
+
+  // ดึงข้อมูลทั้ง 5 sections พร้อมกัน
+  const [sales, appointments, popularServices, reviews, financeChart] =
+    await Promise.all([
+      getSalesSummary(period),
+      getAppointmentSummary(period),
+      getPopularServices(period, 5),
+      getReviewSummary(period),
+      getFinanceChartData(period),
+    ]);
+
+  return (
+    <>
+      <SiteHeader title="ภาพรวมธุรกิจ" />
+
+      <div className="flex flex-col gap-6 w-full py-8 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* ===== Header: ชื่อหน้า + Period Filter ===== */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-end gap-4">
+          {/* ต้องครอบด้วย Suspense เนื่องจาก useSearchParams */}
+          <Suspense fallback={<Skeleton className="h-9 w-[240px]" />}>
+            <DashboardPeriodFilter currentPeriod={period} />
+          </Suspense>
+        </div>
+
+        {/* ===== Row 1: ยอดขาย + การจองคิว (2 cols) ===== */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <SalesOverviewCard summary={sales} period={period} />
+          <AppointmentSummaryCard summary={appointments} period={period} />
+        </div>
+
+        {/* ===== Row 2: Finance Chart (เต็มความกว้าง) ===== */}
+        <FinanceOverviewChart data={financeChart} period={period} />
+
+        {/* ===== Row 3: บริการยอดนิยม + รีวิวลูกค้า (2 cols) ===== */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <PopularServicesCard services={popularServices} period={period} />
+          <ReviewSummaryCard summary={reviews} period={period} />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -23,12 +23,18 @@ import {
   ListTodoIcon,
   PackageIcon,
   WalletIcon,
+  BarChart3Icon,
 } from "lucide-react";
 import { authClient } from "@/lib/auth-client";
 import Link from "next/link";
 
 const data = {
   navMain: [
+    {
+      title: "ภาพรวมธุรกิจ",
+      url: "/dashboard",
+      icon: <BarChart3Icon />,
+    },
     {
       title: "จัดการผู้ใช้",
       url: "/users",

--- a/modules/dashboard/components/AppointmentSummaryCard.tsx
+++ b/modules/dashboard/components/AppointmentSummaryCard.tsx
@@ -1,0 +1,85 @@
+// ===================================================
+// AppointmentSummaryCard.tsx — การ์ดสรุปการจองคิว
+// ===================================================
+// Server Component: แสดงจำนวนนัดหมายแยกตาม status
+// พร้อม badge สีตาม status
+// ===================================================
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { CalendarCheck } from "lucide-react";
+import { AppointmentSummary, DashboardPeriod } from "../types/dashboard";
+
+interface AppointmentSummaryCardProps {
+  summary: AppointmentSummary;
+  period: DashboardPeriod;
+}
+
+// แปลง period เป็นข้อความไทย
+const periodLabel: Record<DashboardPeriod, string> = {
+  DAILY: "วันนี้",
+  MONTHLY: "30 วันล่าสุด",
+  YEARLY: "ปีนี้",
+};
+
+export function AppointmentSummaryCard({
+  summary,
+  period,
+}: AppointmentSummaryCardProps) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <div>
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            การจองคิว
+          </CardTitle>
+          <CardDescription className="text-xs mt-0.5">
+            {periodLabel[period]}
+          </CardDescription>
+        </div>
+        {/* ไอคอนพื้นหลัง */}
+        <div className="bg-blue-500/10 p-2 rounded-lg">
+          <CalendarCheck className="size-4 text-blue-500" />
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-3">
+        {/* จำนวนรวม */}
+        <div className="text-2xl font-bold">{summary.total.toLocaleString()}</div>
+
+        {/* แยกตาม status */}
+        <div className="flex flex-wrap gap-2 text-xs">
+          {/* กำลังดำเนินการ */}
+          <div className="flex items-center gap-1.5">
+            <Badge variant="outline" className="text-blue-600 border-blue-200 bg-blue-50 py-0 px-2">
+              {summary.active}
+            </Badge>
+            <span className="text-muted-foreground">กำลังดำเนินการ</span>
+          </div>
+
+          {/* เสร็จสิ้น */}
+          <div className="flex items-center gap-1.5">
+            <Badge variant="outline" className="text-green-600 border-green-200 bg-green-50 py-0 px-2">
+              {summary.completed}
+            </Badge>
+            <span className="text-muted-foreground">เสร็จสิ้น</span>
+          </div>
+
+          {/* ยกเลิก/ไม่มา */}
+          <div className="flex items-center gap-1.5">
+            <Badge variant="outline" className="text-red-600 border-red-200 bg-red-50 py-0 px-2">
+              {summary.cancelled}
+            </Badge>
+            <span className="text-muted-foreground">ยกเลิก</span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/modules/dashboard/components/DashboardPeriodFilter.tsx
+++ b/modules/dashboard/components/DashboardPeriodFilter.tsx
@@ -1,0 +1,63 @@
+"use client";
+// ===================================================
+// DashboardPeriodFilter.tsx — ตัวกรองช่วงเวลา Dashboard
+// ===================================================
+// Client Component: ใช้ ToggleGroup สำหรับเลือก period
+// อัปเดต URL searchParam เมื่อผู้ใช้เปลี่ยน period
+// ===================================================
+
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { DashboardPeriod } from "../types/dashboard";
+
+// ตัวเลือก period ที่แสดงให้ผู้ใช้
+const PERIOD_OPTIONS: { value: DashboardPeriod; label: string }[] = [
+  { value: "DAILY", label: "รายวัน" },
+  { value: "MONTHLY", label: "รายเดือน" },
+  { value: "YEARLY", label: "รายปี" },
+];
+
+interface DashboardPeriodFilterProps {
+  /** period ปัจจุบันจาก searchParams */
+  currentPeriod: DashboardPeriod;
+}
+
+export function DashboardPeriodFilter({
+  currentPeriod,
+}: DashboardPeriodFilterProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // เปลี่ยน period โดยอัปเดต URL searchParam
+  const handlePeriodChange = useCallback(
+    (value: string) => {
+      if (!value) return; // ป้องกันการ deselect ทั้งหมด
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("period", value);
+      router.push(`${pathname}?${params.toString()}`);
+    },
+    [router, pathname, searchParams]
+  );
+
+  return (
+    <ToggleGroup
+      type="single"
+      value={currentPeriod}
+      onValueChange={handlePeriodChange}
+      className="border rounded-lg p-1 bg-muted/50"
+    >
+      {PERIOD_OPTIONS.map((opt) => (
+        <ToggleGroupItem
+          key={opt.value}
+          value={opt.value}
+          aria-label={`ดูข้อมูล${opt.label}`}
+          className="text-sm px-4 py-1.5 data-[state=on]:bg-background data-[state=on]:shadow-sm"
+        >
+          {opt.label}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  );
+}

--- a/modules/dashboard/components/FinanceOverviewChart.tsx
+++ b/modules/dashboard/components/FinanceOverviewChart.tsx
@@ -1,0 +1,189 @@
+"use client";
+// ===================================================
+// FinanceOverviewChart.tsx — Bar Chart รายรับ-รายจ่าย
+// ===================================================
+// Client Component: ใช้ shadcn Chart (Recharts v3)
+// แสดง income vs expense แบบ side-by-side bar
+// พร้อม summary cards ด้านบน (รายรับ / รายจ่าย / กำไร)
+// ===================================================
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { TrendingUp, TrendingDown, Wallet } from "lucide-react";
+import { FinanceChartData, DashboardPeriod } from "../types/dashboard";
+import { formatCurrency } from "@/lib/utils";
+
+interface FinanceOverviewChartProps {
+  data: FinanceChartData;
+  period: DashboardPeriod;
+}
+
+// แปลง period เป็นข้อความไทย
+const periodLabel: Record<DashboardPeriod, string> = {
+  DAILY: "วันนี้",
+  MONTHLY: "30 วันล่าสุด",
+  YEARLY: "ปีนี้",
+};
+
+// config สำหรับ chart (สี + label)
+const chartConfig = {
+  income: {
+    label: "รายรับ",
+    color: "var(--chart-2)", // เขียว (จาก globals.css)
+  },
+  expense: {
+    label: "รายจ่าย",
+    color: "var(--chart-1)", // ส้ม/แดง
+  },
+} satisfies ChartConfig;
+
+export function FinanceOverviewChart({
+  data,
+  period,
+}: FinanceOverviewChartProps) {
+  const isProfit = data.netProfit >= 0;
+
+  return (
+    <Card className="flex flex-col">
+      <CardHeader>
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+          <div>
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              รายรับ-รายจ่าย
+            </CardTitle>
+            <CardDescription className="text-xs mt-0.5">
+              {periodLabel[period]}
+            </CardDescription>
+          </div>
+
+          {/* Summary 3 ตัว: รายรับ / รายจ่าย / กำไร-ขาดทุน */}
+          <div className="flex gap-4 sm:gap-6">
+            {/* รายรับ */}
+            <div className="flex flex-col">
+              <span className="text-xs text-muted-foreground">รายรับรวม</span>
+              <span className="text-base font-semibold text-green-600">
+                {formatCurrency(data.totalIncome)}
+              </span>
+            </div>
+
+            {/* รายจ่าย */}
+            <div className="flex flex-col">
+              <span className="text-xs text-muted-foreground">รายจ่ายรวม</span>
+              <span className="text-base font-semibold text-red-500">
+                {formatCurrency(data.totalExpense)}
+              </span>
+            </div>
+
+            {/* กำไร/ขาดทุน */}
+            <div className="flex flex-col">
+              <span className="text-xs text-muted-foreground">
+                {isProfit ? "กำไรสุทธิ" : "ขาดทุน"}
+              </span>
+              <div className="flex items-center gap-1">
+                {isProfit ? (
+                  <TrendingUp className="size-3 text-green-600" />
+                ) : (
+                  <TrendingDown className="size-3 text-red-500" />
+                )}
+                <span
+                  className={`text-base font-semibold ${
+                    isProfit ? "text-green-600" : "text-red-500"
+                  }`}
+                >
+                  {formatCurrency(Math.abs(data.netProfit))}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex-1 pt-0">
+        {/* กรณีไม่มีข้อมูล */}
+        {data.points.every((p) => p.income === 0 && p.expense === 0) ? (
+          <div className="flex items-center justify-center h-[200px] text-sm text-muted-foreground">
+            ไม่มีข้อมูลธุรกรรมใน{periodLabel[period]}
+          </div>
+        ) : (
+          <ChartContainer config={chartConfig} className="min-h-[200px] w-full">
+            <BarChart
+              accessibilityLayer
+              data={data.points}
+              margin={{ left: 0, right: 0, top: 4, bottom: 0 }}
+              barGap={4}
+            >
+              <CartesianGrid vertical={false} className="stroke-muted" />
+              <XAxis
+                dataKey="label"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                tick={{ fontSize: 11 }}
+                // ลด label ถ้ามีหลายจุด
+                interval={
+                  data.points.length > 15
+                    ? Math.floor(data.points.length / 10)
+                    : 0
+                }
+              />
+              <YAxis
+                tickLine={false}
+                axisLine={false}
+                tickMargin={4}
+                tick={{ fontSize: 10 }}
+                tickFormatter={(v) =>
+                  v >= 1000 ? `${(v / 1000).toFixed(0)}K` : `${v}`
+                }
+                width={36}
+              />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    formatter={(value, name) => [
+                      formatCurrency(Number(value)),
+                      name,
+                    ]}
+                  />
+                }
+              />
+              <ChartLegend content={<ChartLegendContent />} />
+              <Bar
+                dataKey="income"
+                fill="var(--color-income)"
+                radius={[4, 4, 0, 0]}
+                maxBarSize={40}
+              />
+              <Bar
+                dataKey="expense"
+                fill="var(--color-expense)"
+                radius={[4, 4, 0, 0]}
+                maxBarSize={40}
+              />
+            </BarChart>
+          </ChartContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/modules/dashboard/components/PopularServicesCard.tsx
+++ b/modules/dashboard/components/PopularServicesCard.tsx
@@ -1,0 +1,114 @@
+// ===================================================
+// PopularServicesCard.tsx — การ์ดบริการยอดนิยม TOP 5
+// ===================================================
+// Server Component: แสดงอันดับบริการที่ถูกใช้งานมากที่สุด
+// พร้อมแถบ progress bar แสดงสัดส่วน
+// ===================================================
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Trophy } from "lucide-react";
+import { PopularService, DashboardPeriod } from "../types/dashboard";
+import { formatCurrency } from "@/lib/utils";
+
+interface PopularServicesCardProps {
+  services: PopularService[];
+  period: DashboardPeriod;
+}
+
+// แปลง period เป็นข้อความไทย
+const periodLabel: Record<DashboardPeriod, string> = {
+  DAILY: "วันนี้",
+  MONTHLY: "30 วันล่าสุด",
+  YEARLY: "ปีนี้",
+};
+
+// สีตามอันดับ (1st = gold, 2nd = silver, 3rd = bronze, ที่เหลือ = muted)
+const rankColors = [
+  "text-yellow-500",  // อันดับ 1
+  "text-gray-400",    // อันดับ 2
+  "text-orange-500",  // อันดับ 3
+  "text-muted-foreground", // อันดับ 4
+  "text-muted-foreground", // อันดับ 5
+];
+
+export function PopularServicesCard({
+  services,
+  period,
+}: PopularServicesCardProps) {
+  // หาจำนวนสูงสุดสำหรับคำนวณ progress bar
+  const maxCount = Math.max(...services.map((s) => s.count), 1);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <div>
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            บริการยอดนิยม
+          </CardTitle>
+          <CardDescription className="text-xs mt-0.5">
+            TOP 5 — {periodLabel[period]}
+          </CardDescription>
+        </div>
+        <div className="bg-yellow-500/10 p-2 rounded-lg">
+          <Trophy className="size-4 text-yellow-500" />
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        {services.length === 0 ? (
+          // กรณีไม่มีข้อมูล
+          <p className="text-sm text-muted-foreground text-center py-4">
+            ไม่มีข้อมูลใน{periodLabel[period]}
+          </p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {services.map((service, index) => {
+              const percent = (service.count / maxCount) * 100;
+              return (
+                <div key={service.serviceName} className="flex flex-col gap-1">
+                  {/* แถวอันดับ + ชื่อ + จำนวน */}
+                  <div className="flex items-center justify-between text-sm">
+                    <div className="flex items-center gap-2">
+                      {/* หมายเลขอันดับ */}
+                      <span
+                        className={`font-bold text-xs w-4 ${rankColors[index]}`}
+                      >
+                        {index + 1}
+                      </span>
+                      <span className="font-medium truncate max-w-[160px]">
+                        {service.serviceName}
+                      </span>
+                    </div>
+                    {/* จำนวน + รายได้ */}
+                    <div className="flex items-center gap-2 text-xs shrink-0">
+                      <span className="text-muted-foreground">
+                        {service.count} ครั้ง
+                      </span>
+                      <span className="font-medium text-green-600">
+                        {formatCurrency(service.revenue)}
+                      </span>
+                    </div>
+                  </div>
+
+                  {/* Progress bar */}
+                  <div className="w-full bg-muted rounded-full h-1.5">
+                    <div
+                      className="bg-primary rounded-full h-1.5 transition-all duration-500"
+                      style={{ width: `${percent}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/modules/dashboard/components/ReviewSummaryCard.tsx
+++ b/modules/dashboard/components/ReviewSummaryCard.tsx
@@ -1,0 +1,146 @@
+// ===================================================
+// ReviewSummaryCard.tsx — การ์ดสรุปรีวิวลูกค้า
+// ===================================================
+// Server Component: แสดงคะแนนเฉลี่ย, star distribution
+// และรีวิวล่าสุด 5 รายการ
+// ===================================================
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Star } from "lucide-react";
+import { ReviewSummary, DashboardPeriod } from "../types/dashboard";
+import { formatThaiDate } from "@/lib/utils";
+
+interface ReviewSummaryCardProps {
+  summary: ReviewSummary;
+  period: DashboardPeriod;
+}
+
+// แปลง period เป็นข้อความไทย
+const periodLabel: Record<DashboardPeriod, string> = {
+  DAILY: "วันนี้",
+  MONTHLY: "30 วันล่าสุด",
+  YEARLY: "ปีนี้",
+};
+
+// Component แสดงดาว (filled/empty)
+function StarRating({ rating, size = "sm" }: { rating: number; size?: "sm" | "md" }) {
+  const sizeClass = size === "md" ? "size-5" : "size-3";
+  return (
+    <div className="flex gap-0.5">
+      {[1, 2, 3, 4, 5].map((star) => (
+        <Star
+          key={star}
+          className={`${sizeClass} ${
+            star <= rating
+              ? "fill-yellow-400 text-yellow-400"
+              : "fill-muted text-muted"
+          }`}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function ReviewSummaryCard({ summary, period }: ReviewSummaryCardProps) {
+  // หาจำนวนรีวิวสูงสุดสำหรับ distribution bar
+  const maxDistribution = Math.max(...Object.values(summary.distribution), 1);
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <div>
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            รีวิวลูกค้า
+          </CardTitle>
+          <CardDescription className="text-xs mt-0.5">
+            {periodLabel[period]}
+          </CardDescription>
+        </div>
+        <div className="bg-yellow-400/10 p-2 rounded-lg">
+          <Star className="size-4 text-yellow-400 fill-yellow-400" />
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-4">
+        {/* ส่วนบน: คะแนนเฉลี่ย + star distribution */}
+        <div className="flex gap-4">
+          {/* คะแนนเฉลี่ย */}
+          <div className="flex flex-col items-center justify-center min-w-[80px]">
+            <span className="text-4xl font-bold">
+              {summary.averageRating.toFixed(1)}
+            </span>
+            <StarRating rating={Math.round(summary.averageRating)} size="md" />
+            <span className="text-xs text-muted-foreground mt-1">
+              {summary.totalReviews.toLocaleString()} รีวิว
+            </span>
+          </div>
+
+          {/* Star Distribution bars */}
+          <div className="flex-1 flex flex-col gap-1 justify-center">
+            {([5, 4, 3, 2, 1] as const).map((star) => {
+              const count = summary.distribution[star];
+              const percent = (count / maxDistribution) * 100;
+              return (
+                <div key={star} className="flex items-center gap-2 text-xs">
+                  <span className="w-3 text-muted-foreground text-right">
+                    {star}
+                  </span>
+                  <Star className="size-3 fill-yellow-400 text-yellow-400 shrink-0" />
+                  <div className="flex-1 bg-muted rounded-full h-1.5">
+                    <div
+                      className="bg-yellow-400 rounded-full h-1.5 transition-all duration-500"
+                      style={{ width: `${percent}%` }}
+                    />
+                  </div>
+                  <span className="w-4 text-muted-foreground text-right">
+                    {count}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* กรณีไม่มีรีวิว */}
+        {summary.totalReviews === 0 && (
+          <p className="text-sm text-muted-foreground text-center py-2">
+            ไม่มีรีวิวใน{periodLabel[period]}
+          </p>
+        )}
+
+        {/* รีวิวล่าสุด */}
+        {summary.recentReviews.length > 0 && (
+          <div className="flex flex-col gap-2 pt-2 border-t">
+            <span className="text-xs font-medium text-muted-foreground">
+              รีวิวล่าสุด
+            </span>
+            {summary.recentReviews.map((review) => (
+              <div key={review.id} className="flex flex-col gap-0.5">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium">{review.customerName}</span>
+                  <div className="flex items-center gap-1.5">
+                    <StarRating rating={review.rating} />
+                    <span className="text-xs text-muted-foreground">
+                      {formatThaiDate(review.reviewedAt)}
+                    </span>
+                  </div>
+                </div>
+                {review.comment && (
+                  <p className="text-xs text-muted-foreground line-clamp-1">
+                    {review.comment}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/modules/dashboard/components/SalesOverviewCard.tsx
+++ b/modules/dashboard/components/SalesOverviewCard.tsx
@@ -1,0 +1,74 @@
+// ===================================================
+// SalesOverviewCard.tsx — การ์ดสรุปยอดขาย
+// ===================================================
+// Server Component: แสดงยอดขายรวม + จำนวนรายการ
+// พร้อม badge แสดง % เปลี่ยนแปลงจาก period ก่อน
+// ===================================================
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { TrendingUp, TrendingDown, ShoppingCart } from "lucide-react";
+import { SalesSummary, DashboardPeriod } from "../types/dashboard";
+import { formatCurrency } from "@/lib/utils";
+
+interface SalesOverviewCardProps {
+  summary: SalesSummary;
+  period: DashboardPeriod;
+}
+
+// แปลง period เป็นข้อความไทย
+const periodLabel: Record<DashboardPeriod, string> = {
+  DAILY: "วันนี้",
+  MONTHLY: "30 วันล่าสุด",
+  YEARLY: "ปีนี้",
+};
+
+export function SalesOverviewCard({ summary, period }: SalesOverviewCardProps) {
+  const isPositive = summary.changePercent >= 0;
+  const TrendIcon = isPositive ? TrendingUp : TrendingDown;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between pb-2">
+        <div>
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            ยอดขาย
+          </CardTitle>
+          <CardDescription className="text-xs mt-0.5">
+            {periodLabel[period]}
+          </CardDescription>
+        </div>
+        {/* ไอคอนพื้นหลัง */}
+        <div className="bg-primary/10 p-2 rounded-lg">
+          <ShoppingCart className="size-4 text-primary" />
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex flex-col gap-2">
+        {/* ยอดขายรวม */}
+        <div className="text-2xl font-bold">
+          {formatCurrency(summary.totalRevenue)}
+        </div>
+
+        {/* จำนวนรายการ + % เปลี่ยนแปลง */}
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>{summary.transactionCount} รายการ</span>
+          <Badge
+            variant={isPositive ? "default" : "destructive"}
+            className="text-xs py-0 px-1.5 gap-0.5"
+          >
+            <TrendIcon className="size-3" />
+            {Math.abs(summary.changePercent).toFixed(1)}%
+          </Badge>
+          <span>จาก period ก่อน</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/modules/dashboard/queries/get-appointment-summary.ts
+++ b/modules/dashboard/queries/get-appointment-summary.ts
@@ -1,0 +1,68 @@
+// ===================================================
+// get-appointment-summary.ts — Query ดึงสรุปการจองคิว
+// ===================================================
+// ใช้ Drizzle Query API + date-fns
+// แสดงจำนวนนัดหมายแยกตาม status ใน period ที่เลือก
+// ===================================================
+
+import { db } from "@/db";
+import { appointments } from "@/db/schema";
+import { and, gte, lte, isNull, sql, inArray, notInArray } from "drizzle-orm";
+import { AppointmentSummary, DashboardPeriod } from "../types/dashboard";
+import { getDateRange } from "../utils/date-range";
+
+/**
+ * ดึงสรุปจำนวนการจองคิวแยกตาม status
+ * - active: PENDING_DEPOSIT, PENDING_APPROVAL, CONFIRMED, CHECKED_IN, IN_PROGRESS, READY_FOR_PICKUP
+ * - completed: COMPLETED
+ * - cancelled: CANCELLED, NO_SHOW
+ */
+export async function getAppointmentSummary(
+  period: DashboardPeriod,
+): Promise<AppointmentSummary> {
+  const { startDate, endDate } = getDateRange(period);
+
+  // ดึงจำนวนนัดหมายแยกตาม status ใน 1 query
+  const results = await db
+    .select({
+      status: appointments.status,
+      count: sql<number>`COUNT(*)`.mapWith(Number),
+    })
+    .from(appointments)
+    .where(
+      and(
+        isNull(appointments.deletedAt),
+        gte(appointments.appointmentDate, startDate),
+        lte(appointments.appointmentDate, endDate),
+      ),
+    )
+    .groupBy(appointments.status);
+
+  // รวมผลลัพธ์ตาม group
+  const statusMap = new Map(results.map((r) => [r.status, r.count]));
+
+  // status ที่ถือว่า "กำลังดำเนินการ / รอดำเนินการ"
+  const activeStatuses = [
+    "PENDING_DEPOSIT",
+    "PENDING_APPROVAL",
+    "CONFIRMED",
+    "CHECKED_IN",
+    "IN_PROGRESS",
+    "READY_FOR_PICKUP",
+  ] as const;
+
+  const active = activeStatuses.reduce(
+    (sum, s) => sum + (statusMap.get(s) ?? 0),
+    0,
+  );
+  const completed = statusMap.get("COMPLETED") ?? 0;
+  const cancelled =
+    (statusMap.get("CANCELLED") ?? 0) + (statusMap.get("NO_SHOW") ?? 0);
+
+  return {
+    total: active + completed + cancelled,
+    active,
+    completed,
+    cancelled,
+  };
+}

--- a/modules/dashboard/queries/get-finance-chart-data.ts
+++ b/modules/dashboard/queries/get-finance-chart-data.ts
@@ -86,7 +86,7 @@ export async function getFinanceChartData(
     const results = await db
       .select({
         type: transactionCategories.type,
-        date: transactions.transactionDate,
+        dateString: sql<string>`TO_CHAR(${transactions.transactionDate}, 'YYYY-MM-DD')`,
         total: sql<number>`COALESCE(SUM(${transactions.amount}), 0)`.mapWith(Number),
       })
       .from(transactions)
@@ -113,7 +113,7 @@ export async function getFinanceChartData(
 
     // เติมข้อมูลจริงโดย map transactionDate → วัน
     for (const row of results) {
-      const key = format(new Date(row.date), "yyyy-MM-dd");
+      const key = row.dateString;
       const existing = dayMap.get(key) ?? { income: 0, expense: 0 };
       if (row.type === "INCOME") existing.income += row.total;
       else if (row.type === "EXPENSE") existing.expense += row.total;
@@ -135,7 +135,7 @@ export async function getFinanceChartData(
     const results = await db
       .select({
         type: transactionCategories.type,
-        date: transactions.transactionDate,
+        dateString: sql<string>`TO_CHAR(${transactions.transactionDate}, 'YYYY-MM-DD')`,
         total: sql<number>`COALESCE(SUM(${transactions.amount}), 0)`.mapWith(Number),
       })
       .from(transactions)
@@ -162,7 +162,7 @@ export async function getFinanceChartData(
 
     // เติมข้อมูลจริง
     for (const row of results) {
-      const key = format(new Date(row.date), "yyyy-MM-dd");
+      const key = row.dateString;
       const existing = dayMap.get(key) ?? { income: 0, expense: 0 };
       if (row.type === "INCOME") existing.income = row.total;
       else if (row.type === "EXPENSE") existing.expense = row.total;
@@ -183,7 +183,7 @@ export async function getFinanceChartData(
     const results = await db
       .select({
         type: transactionCategories.type,
-        date: transactions.transactionDate,
+        dateString: sql<string>`TO_CHAR(${transactions.transactionDate}, 'YYYY-MM')`,
         total: sql<number>`COALESCE(SUM(${transactions.amount}), 0)`.mapWith(Number),
       })
       .from(transactions)
@@ -210,7 +210,7 @@ export async function getFinanceChartData(
 
     // เติมข้อมูลจริง (aggregate ด้วย JS โดย map date → month)
     for (const row of results) {
-      const key = format(new Date(row.date), "yyyy-MM");
+      const key = row.dateString;
       const existing = monthMap.get(key) ?? { income: 0, expense: 0 };
       if (row.type === "INCOME") existing.income += row.total;
       else if (row.type === "EXPENSE") existing.expense += row.total;

--- a/modules/dashboard/queries/get-finance-chart-data.ts
+++ b/modules/dashboard/queries/get-finance-chart-data.ts
@@ -10,7 +10,7 @@
 
 import { db } from "@/db";
 import { transactions, transactionCategories } from "@/db/schema";
-import { and, eq, gte, lte, isNull, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { FinanceChartData, FinanceChartPoint, DashboardPeriod } from "../types/dashboard";
 import { getDateRange } from "../utils/date-range";
 import {
@@ -51,8 +51,8 @@ async function getTotalsInRange(
       and(
         isNull(transactions.deletedAt),
         isNull(transactionCategories.deletedAt),
-        gte(transactions.transactionDate, startDate),
-        lte(transactions.transactionDate, endDate)
+        sql`${transactions.transactionDate} >= ${format(startDate, "yyyy-MM-dd")}::date`,
+        sql`${transactions.transactionDate} <= ${format(endDate, "yyyy-MM-dd")}::date`
       )
     )
     .groupBy(transactionCategories.type);
@@ -98,8 +98,8 @@ export async function getFinanceChartData(
         and(
           isNull(transactions.deletedAt),
           isNull(transactionCategories.deletedAt),
-          gte(transactions.transactionDate, startDate),
-          lte(transactions.transactionDate, endDate)
+          sql`${transactions.transactionDate} >= ${format(startDate, "yyyy-MM-dd")}::date`,
+          sql`${transactions.transactionDate} <= ${format(endDate, "yyyy-MM-dd")}::date`
         )
       )
       .groupBy(transactionCategories.type, transactions.transactionDate);
@@ -147,8 +147,8 @@ export async function getFinanceChartData(
         and(
           isNull(transactions.deletedAt),
           isNull(transactionCategories.deletedAt),
-          gte(transactions.transactionDate, startDate),
-          lte(transactions.transactionDate, endDate)
+          sql`${transactions.transactionDate} >= ${format(startDate, "yyyy-MM-dd")}::date`,
+          sql`${transactions.transactionDate} <= ${format(endDate, "yyyy-MM-dd")}::date`
         )
       )
       .groupBy(transactionCategories.type, transactions.transactionDate);
@@ -195,8 +195,8 @@ export async function getFinanceChartData(
         and(
           isNull(transactions.deletedAt),
           isNull(transactionCategories.deletedAt),
-          gte(transactions.transactionDate, startDate),
-          lte(transactions.transactionDate, endDate)
+          sql`${transactions.transactionDate} >= ${format(startDate, "yyyy-MM-dd")}::date`,
+          sql`${transactions.transactionDate} <= ${format(endDate, "yyyy-MM-dd")}::date`
         )
       )
       .groupBy(transactionCategories.type, transactions.transactionDate);

--- a/modules/dashboard/queries/get-finance-chart-data.ts
+++ b/modules/dashboard/queries/get-finance-chart-data.ts
@@ -3,7 +3,7 @@
 // ===================================================
 // ใช้ Drizzle SQL query + date-fns
 // สร้าง time-series data สำหรับ Bar Chart
-// - DAILY: แสดงรายชั่วโมง (00:00 - 23:00) ของวันนี้
+// - DAILY: แสดงรายวันของช่วงที่เลือก (1 จุดต่อวัน)
 // - MONTHLY: แสดงรายวัน 30 วันล่าสุด
 // - YEARLY: แสดงรายเดือน 12 เดือนของปีนี้
 // ===================================================
@@ -15,11 +15,8 @@ import { FinanceChartData, FinanceChartPoint, DashboardPeriod } from "../types/d
 import { getDateRange } from "../utils/date-range";
 import {
   format,
-  eachHourOfInterval,
   eachDayOfInterval,
   eachMonthOfInterval,
-  startOfHour,
-  endOfHour,
   startOfDay,
   endOfDay,
   startOfMonth,
@@ -71,7 +68,7 @@ async function getTotalsInRange(
 
 /**
  * ดึงข้อมูล time-series สำหรับ Bar Chart
- * - DAILY: ทุก 2 ชั่วโมง (12 จุด) ของวันนี้
+ * - DAILY: รายวัน (1 จุดต่อวัน) ของช่วงที่เลือก
  * - MONTHLY: รายวัน 30 วันล่าสุด
  * - YEARLY: รายเดือน 12 เดือนของปีนี้
  */
@@ -83,17 +80,14 @@ export async function getFinanceChartData(
   let points: FinanceChartPoint[] = [];
 
   if (period === "DAILY") {
-    // แบ่งเป็นช่วงละ 2 ชั่วโมง (00:00, 02:00, ..., 22:00) = 12 จุด
-    const hours = eachHourOfInterval({ start: startDate, end: endDate }).filter(
-      (_, i) => i % 2 === 0 // เอาแค่ทุก 2 ชั่วโมง
-    );
-
-    // ดึง transactions ทั้งวันครั้งเดียว แล้ว bucket ด้วย JS
-    const rawData = await db
+    // DAILY: 1 bucket ต่อวัน — ใช้ transactionDate (date-only) เป็น key
+    // เนื่องจาก transactionDate ไม่มีเวลา การแบ่งเป็น hour bucket จะทำให้ข้อมูลกองอยู่ใน bucket เดียว
+    // จึงเปลี่ยนมาใช้ eachDayOfInterval เหมือน MONTHLY แต่ label แสดงเป็นวัน/เดือน
+    const results = await db
       .select({
         type: transactionCategories.type,
-        amount: transactions.amount,
-        transactionDate: transactions.transactionDate,
+        date: transactions.transactionDate,
+        total: sql<number>`COALESCE(SUM(${transactions.amount}), 0)`.mapWith(Number),
       })
       .from(transactions)
       .innerJoin(
@@ -107,33 +101,34 @@ export async function getFinanceChartData(
           gte(transactions.transactionDate, startDate),
           lte(transactions.transactionDate, endDate)
         )
-      );
+      )
+      .groupBy(transactionCategories.type, transactions.transactionDate);
 
-    // สำหรับ DAILY ใช้ hour เป็น bucket (เนื่องจาก transactionDate เป็น date ไม่มีเวลา)
-    // จะสร้าง 12 bucket แต่ข้อมูลจะรวมอยู่ใน bucket แรก (เนื่องจาก date only)
-    // ดังนั้นวันนี้จะแสดงใน 00:00 bucket
-    const buckets = new Map<
-      string,
-      { income: number; expense: number }
-    >();
-    for (const h of hours) {
-      buckets.set(format(h, "HH:00"), { income: 0, expense: 0 });
+    // สร้าง map สำหรับทุกวันในช่วง (DAILY = วันเดียว แต่ใช้ pattern เดียวกับ MONTHLY)
+    const days = eachDayOfInterval({ start: startDate, end: endDate });
+    const dayMap = new Map<string, { income: number; expense: number }>();
+    for (const day of days) {
+      dayMap.set(format(day, "yyyy-MM-dd"), { income: 0, expense: 0 });
     }
 
-    // เติมข้อมูลจริง (ทุก transaction ของวันนี้รวมอยู่ใน "00:00" bucket)
-    for (const row of rawData) {
-      const key = "00:00"; // date-only field → ไม่มีเวลา ใส่ใน bucket แรก
-      const bucket = buckets.get(key) ?? { income: 0, expense: 0 };
-      const amount = Number(row.amount);
-      if (row.type === "INCOME") bucket.income += amount;
-      else if (row.type === "EXPENSE") bucket.expense += amount;
-      buckets.set(key, bucket);
+    // เติมข้อมูลจริงโดย map transactionDate → วัน
+    for (const row of results) {
+      const key = format(new Date(row.date), "yyyy-MM-dd");
+      const existing = dayMap.get(key) ?? { income: 0, expense: 0 };
+      if (row.type === "INCOME") existing.income += row.total;
+      else if (row.type === "EXPENSE") existing.expense += row.total;
+      dayMap.set(key, existing);
     }
 
-    points = hours.map((h) => {
-      const key = format(h, "HH:00");
-      const bucket = buckets.get(key) ?? { income: 0, expense: 0 };
-      return { label: key, income: bucket.income, expense: bucket.expense };
+    // แปลง map → points โดย label แสดงเป็น "d MMM" (เช่น "28 เม.ย.")
+    points = days.map((day) => {
+      const key = format(day, "yyyy-MM-dd");
+      const bucket = dayMap.get(key) ?? { income: 0, expense: 0 };
+      return {
+        label: format(day, "d MMM", { locale: th }),
+        income: bucket.income,
+        expense: bucket.expense,
+      };
     });
   } else if (period === "MONTHLY") {
     // รายวัน 30 วันล่าสุด: ดึง aggregate รายวันด้วย SQL GROUP BY date

--- a/modules/dashboard/queries/get-finance-chart-data.ts
+++ b/modules/dashboard/queries/get-finance-chart-data.ts
@@ -1,0 +1,246 @@
+// ===================================================
+// get-finance-chart-data.ts — Query ดึงข้อมูล Chart รายรับ-รายจ่าย
+// ===================================================
+// ใช้ Drizzle SQL query + date-fns
+// สร้าง time-series data สำหรับ Bar Chart
+// - DAILY: แสดงรายชั่วโมง (00:00 - 23:00) ของวันนี้
+// - MONTHLY: แสดงรายวัน 30 วันล่าสุด
+// - YEARLY: แสดงรายเดือน 12 เดือนของปีนี้
+// ===================================================
+
+import { db } from "@/db";
+import { transactions, transactionCategories } from "@/db/schema";
+import { and, eq, gte, lte, isNull, sql } from "drizzle-orm";
+import { FinanceChartData, FinanceChartPoint, DashboardPeriod } from "../types/dashboard";
+import { getDateRange } from "../utils/date-range";
+import {
+  format,
+  eachHourOfInterval,
+  eachDayOfInterval,
+  eachMonthOfInterval,
+  startOfHour,
+  endOfHour,
+  startOfDay,
+  endOfDay,
+  startOfMonth,
+  endOfMonth,
+} from "date-fns";
+import { th } from "date-fns/locale";
+
+// ===================================================
+// Helper: ดึงข้อมูล income/expense รวมในช่วงเวลาหนึ่ง
+// ===================================================
+
+type PeriodTotals = {
+  income: number;
+  expense: number;
+};
+
+async function getTotalsInRange(
+  startDate: Date,
+  endDate: Date
+): Promise<PeriodTotals> {
+  const results = await db
+    .select({
+      type: transactionCategories.type,
+      total: sql<number>`COALESCE(SUM(${transactions.amount}), 0)`.mapWith(Number),
+    })
+    .from(transactions)
+    .innerJoin(
+      transactionCategories,
+      eq(transactions.transactionCategoryId, transactionCategories.id)
+    )
+    .where(
+      and(
+        isNull(transactions.deletedAt),
+        isNull(transactionCategories.deletedAt),
+        gte(transactions.transactionDate, startDate),
+        lte(transactions.transactionDate, endDate)
+      )
+    )
+    .groupBy(transactionCategories.type);
+
+  let income = 0;
+  let expense = 0;
+  for (const row of results) {
+    if (row.type === "INCOME") income = row.total;
+    else if (row.type === "EXPENSE") expense = row.total;
+  }
+  return { income, expense };
+}
+
+/**
+ * ดึงข้อมูล time-series สำหรับ Bar Chart
+ * - DAILY: ทุก 2 ชั่วโมง (12 จุด) ของวันนี้
+ * - MONTHLY: รายวัน 30 วันล่าสุด
+ * - YEARLY: รายเดือน 12 เดือนของปีนี้
+ */
+export async function getFinanceChartData(
+  period: DashboardPeriod
+): Promise<FinanceChartData> {
+  const { startDate, endDate } = getDateRange(period);
+
+  let points: FinanceChartPoint[] = [];
+
+  if (period === "DAILY") {
+    // แบ่งเป็นช่วงละ 2 ชั่วโมง (00:00, 02:00, ..., 22:00) = 12 จุด
+    const hours = eachHourOfInterval({ start: startDate, end: endDate }).filter(
+      (_, i) => i % 2 === 0 // เอาแค่ทุก 2 ชั่วโมง
+    );
+
+    // ดึง transactions ทั้งวันครั้งเดียว แล้ว bucket ด้วย JS
+    const rawData = await db
+      .select({
+        type: transactionCategories.type,
+        amount: transactions.amount,
+        transactionDate: transactions.transactionDate,
+      })
+      .from(transactions)
+      .innerJoin(
+        transactionCategories,
+        eq(transactions.transactionCategoryId, transactionCategories.id)
+      )
+      .where(
+        and(
+          isNull(transactions.deletedAt),
+          isNull(transactionCategories.deletedAt),
+          gte(transactions.transactionDate, startDate),
+          lte(transactions.transactionDate, endDate)
+        )
+      );
+
+    // สำหรับ DAILY ใช้ hour เป็น bucket (เนื่องจาก transactionDate เป็น date ไม่มีเวลา)
+    // จะสร้าง 12 bucket แต่ข้อมูลจะรวมอยู่ใน bucket แรก (เนื่องจาก date only)
+    // ดังนั้นวันนี้จะแสดงใน 00:00 bucket
+    const buckets = new Map<
+      string,
+      { income: number; expense: number }
+    >();
+    for (const h of hours) {
+      buckets.set(format(h, "HH:00"), { income: 0, expense: 0 });
+    }
+
+    // เติมข้อมูลจริง (ทุก transaction ของวันนี้รวมอยู่ใน "00:00" bucket)
+    for (const row of rawData) {
+      const key = "00:00"; // date-only field → ไม่มีเวลา ใส่ใน bucket แรก
+      const bucket = buckets.get(key) ?? { income: 0, expense: 0 };
+      const amount = Number(row.amount);
+      if (row.type === "INCOME") bucket.income += amount;
+      else if (row.type === "EXPENSE") bucket.expense += amount;
+      buckets.set(key, bucket);
+    }
+
+    points = hours.map((h) => {
+      const key = format(h, "HH:00");
+      const bucket = buckets.get(key) ?? { income: 0, expense: 0 };
+      return { label: key, income: bucket.income, expense: bucket.expense };
+    });
+  } else if (period === "MONTHLY") {
+    // รายวัน 30 วันล่าสุด: ดึง aggregate รายวันด้วย SQL GROUP BY date
+    const results = await db
+      .select({
+        type: transactionCategories.type,
+        date: transactions.transactionDate,
+        total: sql<number>`COALESCE(SUM(${transactions.amount}), 0)`.mapWith(Number),
+      })
+      .from(transactions)
+      .innerJoin(
+        transactionCategories,
+        eq(transactions.transactionCategoryId, transactionCategories.id)
+      )
+      .where(
+        and(
+          isNull(transactions.deletedAt),
+          isNull(transactionCategories.deletedAt),
+          gte(transactions.transactionDate, startDate),
+          lte(transactions.transactionDate, endDate)
+        )
+      )
+      .groupBy(transactionCategories.type, transactions.transactionDate);
+
+    // สร้าง map สำหรับทุกวันใน 30 วัน
+    const days = eachDayOfInterval({ start: startDate, end: endDate });
+    const dayMap = new Map<string, { income: number; expense: number }>();
+    for (const day of days) {
+      dayMap.set(format(day, "yyyy-MM-dd"), { income: 0, expense: 0 });
+    }
+
+    // เติมข้อมูลจริง
+    for (const row of results) {
+      const key = format(new Date(row.date), "yyyy-MM-dd");
+      const existing = dayMap.get(key) ?? { income: 0, expense: 0 };
+      if (row.type === "INCOME") existing.income = row.total;
+      else if (row.type === "EXPENSE") existing.expense = row.total;
+      dayMap.set(key, existing);
+    }
+
+    points = days.map((day) => {
+      const key = format(day, "yyyy-MM-dd");
+      const bucket = dayMap.get(key) ?? { income: 0, expense: 0 };
+      return {
+        label: format(day, "d MMM", { locale: th }), // เช่น "1 เม.ย."
+        income: bucket.income,
+        expense: bucket.expense,
+      };
+    });
+  } else {
+    // YEARLY: รายเดือน 12 เดือนของปีนี้
+    const results = await db
+      .select({
+        type: transactionCategories.type,
+        date: transactions.transactionDate,
+        total: sql<number>`COALESCE(SUM(${transactions.amount}), 0)`.mapWith(Number),
+      })
+      .from(transactions)
+      .innerJoin(
+        transactionCategories,
+        eq(transactions.transactionCategoryId, transactionCategories.id)
+      )
+      .where(
+        and(
+          isNull(transactions.deletedAt),
+          isNull(transactionCategories.deletedAt),
+          gte(transactions.transactionDate, startDate),
+          lte(transactions.transactionDate, endDate)
+        )
+      )
+      .groupBy(transactionCategories.type, transactions.transactionDate);
+
+    // สร้าง map 12 เดือน
+    const months = eachMonthOfInterval({ start: startDate, end: endDate });
+    const monthMap = new Map<string, { income: number; expense: number }>();
+    for (const month of months) {
+      monthMap.set(format(month, "yyyy-MM"), { income: 0, expense: 0 });
+    }
+
+    // เติมข้อมูลจริง (aggregate ด้วย JS โดย map date → month)
+    for (const row of results) {
+      const key = format(new Date(row.date), "yyyy-MM");
+      const existing = monthMap.get(key) ?? { income: 0, expense: 0 };
+      if (row.type === "INCOME") existing.income += row.total;
+      else if (row.type === "EXPENSE") existing.expense += row.total;
+      monthMap.set(key, existing);
+    }
+
+    points = months.map((month) => {
+      const key = format(month, "yyyy-MM");
+      const bucket = monthMap.get(key) ?? { income: 0, expense: 0 };
+      return {
+        label: format(month, "MMM", { locale: th }), // เช่น "ม.ค."
+        income: bucket.income,
+        expense: bucket.expense,
+      };
+    });
+  }
+
+  // คำนวณยอดรวม
+  const totalIncome = points.reduce((sum, p) => sum + p.income, 0);
+  const totalExpense = points.reduce((sum, p) => sum + p.expense, 0);
+
+  return {
+    points,
+    totalIncome,
+    totalExpense,
+    netProfit: totalIncome - totalExpense,
+  };
+}

--- a/modules/dashboard/queries/get-popular-services.ts
+++ b/modules/dashboard/queries/get-popular-services.ts
@@ -1,0 +1,63 @@
+// ===================================================
+// get-popular-services.ts — Query ดึงบริการยอดนิยม
+// ===================================================
+// ใช้ Drizzle SQL query (JOIN หลายตาราง) + date-fns
+// นับจำนวน appointment_items แยกตาม service
+// และรวมรายได้โดยอิงจาก price ของแต่ละ item
+// ===================================================
+
+import { db } from "@/db";
+import { appointmentItems, serviceVariants, services, appointments } from "@/db/schema";
+import { and, eq, gte, lte, isNull, sql, desc } from "drizzle-orm";
+import { PopularService, DashboardPeriod } from "../types/dashboard";
+import { getDateRange } from "../utils/date-range";
+
+/**
+ * ดึง TOP 5 บริการยอดนิยมตาม period ที่เลือก
+ * - นับจาก appointment_items ที่อยู่ใน appointments ของ period นั้น
+ * - GROUP BY services.name
+ * - เรียงจากมากไปน้อย (count DESC)
+ */
+export async function getPopularServices(
+  period: DashboardPeriod,
+  limit: number = 5
+): Promise<PopularService[]> {
+  const { startDate, endDate } = getDateRange(period);
+
+  // JOIN: appointment_items → appointments (สำหรับ filter วันที่)
+  //       appointment_items → service_variants → services (สำหรับชื่อบริการ)
+  const results = await db
+    .select({
+      serviceName: services.name,
+      count: sql<number>`COUNT(${appointmentItems.id})`.mapWith(Number),
+      revenue: sql<number>`COALESCE(SUM(${appointmentItems.price}), 0)`.mapWith(Number),
+    })
+    .from(appointmentItems)
+    .innerJoin(
+      appointments,
+      eq(appointmentItems.appointmentId, appointments.id)
+    )
+    .innerJoin(
+      serviceVariants,
+      eq(appointmentItems.serviceVariantId, serviceVariants.id)
+    )
+    .innerJoin(services, eq(serviceVariants.serviceId, services.id))
+    .where(
+      and(
+        isNull(appointmentItems.deletedAt),
+        isNull(appointments.deletedAt),
+        isNull(services.deletedAt),
+        gte(appointments.appointmentDate, startDate),
+        lte(appointments.appointmentDate, endDate)
+      )
+    )
+    .groupBy(services.id, services.name)
+    .orderBy(desc(sql`COUNT(${appointmentItems.id})`))
+    .limit(limit);
+
+  return results.map((row) => ({
+    serviceName: row.serviceName,
+    count: row.count,
+    revenue: row.revenue,
+  }));
+}

--- a/modules/dashboard/queries/get-popular-services.ts
+++ b/modules/dashboard/queries/get-popular-services.ts
@@ -53,6 +53,7 @@ export async function getPopularServices(
       and(
         isNull(appointmentItems.deletedAt),
         isNull(appointments.deletedAt),
+        isNull(serviceVariants.deletedAt),
         isNull(services.deletedAt),
         notInArray(appointments.status, ["CANCELLED", "NO_SHOW"]),
         gte(appointments.appointmentDate, startDate),

--- a/modules/dashboard/queries/get-popular-services.ts
+++ b/modules/dashboard/queries/get-popular-services.ts
@@ -7,8 +7,13 @@
 // ===================================================
 
 import { db } from "@/db";
-import { appointmentItems, serviceVariants, services, appointments } from "@/db/schema";
-import { and, eq, gte, lte, isNull, sql, desc } from "drizzle-orm";
+import {
+  appointmentItems,
+  serviceVariants,
+  services,
+  appointments,
+} from "@/db/schema";
+import { and, eq, gte, lte, isNull, sql, desc, notInArray } from "drizzle-orm";
 import { PopularService, DashboardPeriod } from "../types/dashboard";
 import { getDateRange } from "../utils/date-range";
 
@@ -20,7 +25,7 @@ import { getDateRange } from "../utils/date-range";
  */
 export async function getPopularServices(
   period: DashboardPeriod,
-  limit: number = 5
+  limit: number = 5,
 ): Promise<PopularService[]> {
   const { startDate, endDate } = getDateRange(period);
 
@@ -30,16 +35,18 @@ export async function getPopularServices(
     .select({
       serviceName: services.name,
       count: sql<number>`COUNT(${appointmentItems.id})`.mapWith(Number),
-      revenue: sql<number>`COALESCE(SUM(${appointmentItems.price}), 0)`.mapWith(Number),
+      revenue: sql<number>`COALESCE(SUM(${appointmentItems.price}), 0)`.mapWith(
+        Number,
+      ),
     })
     .from(appointmentItems)
     .innerJoin(
       appointments,
-      eq(appointmentItems.appointmentId, appointments.id)
+      eq(appointmentItems.appointmentId, appointments.id),
     )
     .innerJoin(
       serviceVariants,
-      eq(appointmentItems.serviceVariantId, serviceVariants.id)
+      eq(appointmentItems.serviceVariantId, serviceVariants.id),
     )
     .innerJoin(services, eq(serviceVariants.serviceId, services.id))
     .where(
@@ -47,9 +54,10 @@ export async function getPopularServices(
         isNull(appointmentItems.deletedAt),
         isNull(appointments.deletedAt),
         isNull(services.deletedAt),
+        notInArray(appointments.status, ["CANCELLED", "NO_SHOW"]),
         gte(appointments.appointmentDate, startDate),
-        lte(appointments.appointmentDate, endDate)
-      )
+        lte(appointments.appointmentDate, endDate),
+      ),
     )
     .groupBy(services.id, services.name)
     .orderBy(desc(sql`COUNT(${appointmentItems.id})`))

--- a/modules/dashboard/queries/get-review-summary.ts
+++ b/modules/dashboard/queries/get-review-summary.ts
@@ -1,0 +1,109 @@
+// ===================================================
+// get-review-summary.ts — Query ดึงสรุปรีวิวลูกค้า
+// ===================================================
+// ใช้ Drizzle Query API (db.query) + date-fns
+// แสดงคะแนนเฉลี่ย, จำนวนรีวิว, distribution และรีวิวล่าสุด
+// ===================================================
+
+import { db } from "@/db";
+import { reviews, customers, appointments } from "@/db/schema";
+import { and, eq, gte, lte, isNull, sql, desc, avg, count } from "drizzle-orm";
+import { ReviewSummary, RecentReview, DashboardPeriod } from "../types/dashboard";
+import { getDateRange } from "../utils/date-range";
+
+/**
+ * ดึงสรุปรีวิวของลูกค้าตาม period ที่เลือก
+ * - คำนวณคะแนนเฉลี่ย
+ * - นับจำนวนรีวิวทั้งหมด
+ * - หาการกระจายตัวของคะแนน (1-5 stars)
+ * - ดึงรีวิวล่าสุด 5 รายการพร้อมชื่อลูกค้า
+ */
+export async function getReviewSummary(
+  period: DashboardPeriod
+): Promise<ReviewSummary> {
+  const { startDate, endDate } = getDateRange(period);
+
+  // กรองตาม appointment_date ของนัดหมายที่รีวิว
+  const dateFilter = and(
+    isNull(reviews.deletedAt),
+    isNull(appointments.deletedAt),
+    gte(appointments.appointmentDate, startDate),
+    lte(appointments.appointmentDate, endDate)
+  );
+
+  // ดึง aggregate stats + distribution พร้อมกัน
+  const [statsResult, distributionResult, recentReviewsResult] =
+    await Promise.all([
+      // คะแนนเฉลี่ย + จำนวนรีวิว
+      db
+        .select({
+          averageRating:
+            sql<number>`COALESCE(AVG(${reviews.rating}), 0)`.mapWith(Number),
+          totalReviews: sql<number>`COUNT(${reviews.id})`.mapWith(Number),
+        })
+        .from(reviews)
+        .innerJoin(appointments, eq(reviews.appointmentId, appointments.id))
+        .where(dateFilter),
+
+      // การกระจายตัวของคะแนน (1-5 stars)
+      db
+        .select({
+          rating: reviews.rating,
+          count: sql<number>`COUNT(*)`.mapWith(Number),
+        })
+        .from(reviews)
+        .innerJoin(appointments, eq(reviews.appointmentId, appointments.id))
+        .where(dateFilter)
+        .groupBy(reviews.rating),
+
+      // รีวิวล่าสุด 5 รายการพร้อมชื่อเล่นลูกค้า (customers.nickname)
+      db
+        .select({
+          id: reviews.id,
+          rating: reviews.rating,
+          comment: reviews.comment,
+          customerName: customers.nickname, // ใช้ nickname เนื่องจาก customers ไม่มีฟิลด์ name
+          appointmentDate: appointments.appointmentDate,
+        })
+        .from(reviews)
+        .innerJoin(appointments, eq(reviews.appointmentId, appointments.id))
+        .innerJoin(customers, eq(reviews.customerId, customers.id))
+        .where(dateFilter)
+        .orderBy(desc(reviews.createdAt))
+        .limit(5),
+    ]);
+
+  // สร้าง distribution map (default = 0 ทุกดาว)
+  const distribution: Record<1 | 2 | 3 | 4 | 5, number> = {
+    1: 0,
+    2: 0,
+    3: 0,
+    4: 0,
+    5: 0,
+  };
+  for (const row of distributionResult) {
+    const star = row.rating as 1 | 2 | 3 | 4 | 5;
+    if (star >= 1 && star <= 5) {
+      distribution[star] = row.count;
+    }
+  }
+
+  // แปลง recentReviews
+  const recentReviews: RecentReview[] = recentReviewsResult.map((r) => ({
+    id: r.id,
+    rating: r.rating,
+    comment: r.comment,
+    customerName: r.customerName,
+    reviewedAt: new Date(r.appointmentDate),
+  }));
+
+  const averageRating = statsResult[0]?.averageRating ?? 0;
+  const totalReviews = statsResult[0]?.totalReviews ?? 0;
+
+  return {
+    averageRating: Math.round(averageRating * 10) / 10, // ปัดทศนิยม 1 ตำแหน่ง
+    totalReviews,
+    distribution,
+    recentReviews,
+  };
+}

--- a/modules/dashboard/queries/get-review-summary.ts
+++ b/modules/dashboard/queries/get-review-summary.ts
@@ -23,12 +23,13 @@ export async function getReviewSummary(
 ): Promise<ReviewSummary> {
   const { startDate, endDate } = getDateRange(period);
 
-  // กรองตาม appointment_date ของนัดหมายที่รีวิว
+  // กรองตาม reviews.createdAt เพื่อให้ period ตรงกับวันที่เขียนรีวิวจริง
+  // (ไม่ใช่ appointmentDate ซึ่งเป็นวันนัดหมาย อาจอยู่คนละช่วงเวลากัน)
   const dateFilter = and(
     isNull(reviews.deletedAt),
     isNull(appointments.deletedAt),
-    gte(appointments.appointmentDate, startDate),
-    lte(appointments.appointmentDate, endDate)
+    gte(reviews.createdAt, startDate),
+    lte(reviews.createdAt, endDate)
   );
 
   // ดึง aggregate stats + distribution พร้อมกัน
@@ -63,7 +64,7 @@ export async function getReviewSummary(
           rating: reviews.rating,
           comment: reviews.comment,
           customerName: customers.nickname, // ใช้ nickname เนื่องจาก customers ไม่มีฟิลด์ name
-          appointmentDate: appointments.appointmentDate,
+          reviewCreatedAt: reviews.createdAt, // วันที่เขียนรีวิวจริง (ไม่ใช่ appointmentDate)
         })
         .from(reviews)
         .innerJoin(appointments, eq(reviews.appointmentId, appointments.id))
@@ -88,13 +89,13 @@ export async function getReviewSummary(
     }
   }
 
-  // แปลง recentReviews
+  // แปลง recentReviews โดยใช้ reviewCreatedAt (วันที่เขียนรีวิวจริง) เป็น reviewedAt
   const recentReviews: RecentReview[] = recentReviewsResult.map((r) => ({
     id: r.id,
     rating: r.rating,
     comment: r.comment,
     customerName: r.customerName,
-    reviewedAt: new Date(r.appointmentDate),
+    reviewedAt: new Date(r.reviewCreatedAt), // มาจาก reviews.createdAt ไม่ใช่ appointmentDate
   }));
 
   const averageRating = statsResult[0]?.averageRating ?? 0;

--- a/modules/dashboard/queries/get-sales-summary.ts
+++ b/modules/dashboard/queries/get-sales-summary.ts
@@ -1,0 +1,84 @@
+// ===================================================
+// get-sales-summary.ts — Query ดึงสรุปยอดขายจาก payments
+// ===================================================
+// ใช้ Drizzle Query API + date-fns
+// ดึงข้อมูล payments ที่มีสถานะ PAID แยกตาม period
+// พร้อมเปรียบเทียบกับ period ก่อนหน้า
+// ===================================================
+
+import { db } from "@/db";
+import { payments } from "@/db/schema";
+import { and, eq, gte, lte, isNull, sql } from "drizzle-orm";
+import { SalesSummary, DashboardPeriod } from "../types/dashboard";
+import { getDateRange, getPreviousDateRange } from "../utils/date-range";
+
+/**
+ * ดึงสรุปยอดขายจากตาราง payments
+ * - กรองเฉพาะ status = "PAID"
+ * - คำนวณยอดรวม + จำนวนครั้ง
+ * - เปรียบเทียบกับ period ก่อนหน้าเพื่อหา % เปลี่ยนแปลง
+ */
+export async function getSalesSummary(
+  period: DashboardPeriod
+): Promise<SalesSummary> {
+  const { startDate, endDate } = getDateRange(period);
+  const { startDate: prevStart, endDate: prevEnd } =
+    getPreviousDateRange(period);
+
+  // ดึงยอดขาย period ปัจจุบัน + period ก่อนหน้าพร้อมกัน
+  const [currentResult, previousResult] = await Promise.all([
+    // period ปัจจุบัน
+    db
+      .select({
+        totalRevenue:
+          sql<number>`COALESCE(SUM(${payments.amount}), 0)`.mapWith(Number),
+        transactionCount: sql<number>`COUNT(*)`.mapWith(Number),
+      })
+      .from(payments)
+      .where(
+        and(
+          eq(payments.status, "PAID"),
+          isNull(payments.deletedAt),
+          gte(payments.paymentDate, startDate),
+          lte(payments.paymentDate, endDate)
+        )
+      ),
+
+    // period ก่อนหน้า (สำหรับ % เปลี่ยนแปลง)
+    db
+      .select({
+        totalRevenue:
+          sql<number>`COALESCE(SUM(${payments.amount}), 0)`.mapWith(Number),
+      })
+      .from(payments)
+      .where(
+        and(
+          eq(payments.status, "PAID"),
+          isNull(payments.deletedAt),
+          gte(payments.paymentDate, prevStart),
+          lte(payments.paymentDate, prevEnd)
+        )
+      ),
+  ]);
+
+  const totalRevenue = currentResult[0]?.totalRevenue ?? 0;
+  const transactionCount = currentResult[0]?.transactionCount ?? 0;
+  const previousRevenue = previousResult[0]?.totalRevenue ?? 0;
+
+  // คำนวณ % เปลี่ยนแปลง (ป้องกัน division by zero)
+  let changePercent = 0;
+  if (previousRevenue > 0) {
+    changePercent =
+      ((totalRevenue - previousRevenue) / previousRevenue) * 100;
+  } else if (totalRevenue > 0) {
+    // period ก่อนไม่มียอด แต่ period นี้มี → เพิ่ม 100%
+    changePercent = 100;
+  }
+
+  return {
+    totalRevenue,
+    transactionCount,
+    previousRevenue,
+    changePercent: Math.round(changePercent * 100) / 100, // ปัดทศนิยม 2 ตำแหน่ง
+  };
+}

--- a/modules/dashboard/types/dashboard.ts
+++ b/modules/dashboard/types/dashboard.ts
@@ -1,0 +1,105 @@
+// ===================================================
+// dashboard.ts — Type Definitions สำหรับ Dashboard
+// ===================================================
+
+// ช่วงเวลาที่ใช้ filter ข้อมูล Dashboard
+export type DashboardPeriod = "DAILY" | "MONTHLY" | "YEARLY";
+
+// ===================================================
+// 💰 ยอดขาย (Sales)
+// ===================================================
+
+// สรุปยอดขายจาก payments ที่มีสถานะ PAID
+export type SalesSummary = {
+  /** ยอดขายรวมใน period ปัจจุบัน (บาท) */
+  totalRevenue: number;
+  /** จำนวนรายการชำระเงิน */
+  transactionCount: number;
+  /** ยอดขายรวมใน period ก่อนหน้า (สำหรับคำนวณ % เปลี่ยนแปลง) */
+  previousRevenue: number;
+  /** % เปลี่ยนแปลงจาก period ก่อน (บวก = เพิ่ม, ลบ = ลด) */
+  changePercent: number;
+};
+
+// ===================================================
+// 📅 การจองคิว (Appointments)
+// ===================================================
+
+// สรุปจำนวนการจองคิวแยกตาม status
+export type AppointmentSummary = {
+  /** จำนวนทั้งหมด */
+  total: number;
+  /** กำลังดำเนินการ/ยืนยันแล้ว */
+  active: number;
+  /** เสร็จสิ้นแล้ว */
+  completed: number;
+  /** ยกเลิก + ไม่มาตามนัด */
+  cancelled: number;
+};
+
+// ===================================================
+// 🏆 บริการยอดนิยม (Popular Services)
+// ===================================================
+
+// ข้อมูลบริการแต่ละรายการในอันดับ
+export type PopularService = {
+  /** ชื่อบริการหลัก */
+  serviceName: string;
+  /** จำนวนครั้งที่ถูกใช้งาน */
+  count: number;
+  /** รายได้รวมจากบริการนี้ (บาท) */
+  revenue: number;
+};
+
+// ===================================================
+// ⭐ รีวิวลูกค้า (Reviews)
+// ===================================================
+
+// สรุปรีวิวทั้งหมด
+export type ReviewSummary = {
+  /** คะแนนเฉลี่ย (1.0 - 5.0) */
+  averageRating: number;
+  /** จำนวนรีวิวทั้งหมด */
+  totalReviews: number;
+  /** การกระจายตัวของคะแนน (key = 1-5) */
+  distribution: Record<1 | 2 | 3 | 4 | 5, number>;
+  /** รีวิวล่าสุด 5 รายการ */
+  recentReviews: RecentReview[];
+};
+
+// ข้อมูลรีวิวแต่ละรายการสำหรับแสดงในหน้า Dashboard
+export type RecentReview = {
+  id: string;
+  rating: number;
+  comment: string | null;
+  /** ชื่อลูกค้า */
+  customerName: string;
+  /** วันที่รีวิว (จาก appointment date) */
+  reviewedAt: Date;
+};
+
+// ===================================================
+// 📊 Chart รายรับ-รายจ่าย (Finance Chart)
+// ===================================================
+
+// จุดข้อมูลใน chart แต่ละจุด
+export type FinanceChartPoint = {
+  /** label แกน X (เช่น "08:00", "01 เม.ย.", "ม.ค.") */
+  label: string;
+  /** รายรับรวม (บาท) */
+  income: number;
+  /** รายจ่ายรวม (บาท) */
+  expense: number;
+};
+
+// ข้อมูล chart พร้อม summary
+export type FinanceChartData = {
+  /** จุดข้อมูลทั้งหมด */
+  points: FinanceChartPoint[];
+  /** ยอดรายรับรวมทั้ง period */
+  totalIncome: number;
+  /** ยอดรายจ่ายรวมทั้ง period */
+  totalExpense: number;
+  /** กำไร/ขาดทุน (income - expense) */
+  netProfit: number;
+};

--- a/modules/dashboard/types/dashboard.ts
+++ b/modules/dashboard/types/dashboard.ts
@@ -74,7 +74,7 @@ export type RecentReview = {
   comment: string | null;
   /** ชื่อลูกค้า */
   customerName: string;
-  /** วันที่รีวิว (จาก appointment date) */
+  /** วันที่เขียนรีวิว (จาก reviews.createdAt) */
   reviewedAt: Date;
 };
 

--- a/modules/dashboard/utils/date-range.ts
+++ b/modules/dashboard/utils/date-range.ts
@@ -1,0 +1,90 @@
+// ===================================================
+// date-range.ts — Utility สำหรับคำนวณช่วงวันที่ Dashboard
+// ===================================================
+// ใช้ date-fns เพื่อคำนวณ start/end ของแต่ละ period
+// รองรับ: DAILY (วันนี้ทั้งวัน), MONTHLY (30 วันล่าสุด), YEARLY (ปีนี้)
+// ===================================================
+
+import {
+  startOfDay,
+  endOfDay,
+  subDays,
+  startOfYear,
+  endOfYear,
+} from "date-fns";
+import { DashboardPeriod } from "../types/dashboard";
+
+// ช่วงวันที่สำหรับ period ปัจจุบัน
+export type DateRange = {
+  startDate: Date;
+  endDate: Date;
+};
+
+/**
+ * คืนค่าช่วงวันที่สำหรับ period ที่เลือก
+ * - DAILY: ตั้งแต่ต้นวันจนสิ้นวันของวันนี้ (สำหรับ chart แบ่งเป็นชั่วโมง)
+ * - MONTHLY: 30 วันล่าสุด (นับจากวันนี้ย้อนกลับ)
+ * - YEARLY: ตั้งแต่ต้นปีจนสิ้นปีของปีนี้
+ */
+export function getDateRange(
+  period: DashboardPeriod,
+  baseDate: Date = new Date()
+): DateRange {
+  switch (period) {
+    case "DAILY":
+      // วันนี้เท่านั้น (00:00 - 23:59)
+      return {
+        startDate: startOfDay(baseDate),
+        endDate: endOfDay(baseDate),
+      };
+
+    case "MONTHLY":
+      // 30 วันล่าสุด ย้อนหลังจากวันนี้
+      return {
+        startDate: startOfDay(subDays(baseDate, 29)), // -29 วัน + วันนี้ = 30 วัน
+        endDate: endOfDay(baseDate),
+      };
+
+    case "YEARLY":
+      // ปีนี้ตั้งแต่ 1 ม.ค. ถึง 31 ธ.ค.
+      return {
+        startDate: startOfYear(baseDate),
+        endDate: endOfYear(baseDate),
+      };
+  }
+}
+
+/**
+ * คืนค่าช่วงวันที่ของ period ก่อนหน้า (สำหรับคำนวณ % เปลี่ยนแปลง)
+ * - DAILY: เมื่อวาน
+ * - MONTHLY: 30 วันก่อนหน้าช่วง 30 วันล่าสุด (วันที่ 31-60 ที่แล้ว)
+ * - YEARLY: ปีที่แล้ว
+ */
+export function getPreviousDateRange(
+  period: DashboardPeriod,
+  baseDate: Date = new Date()
+): DateRange {
+  switch (period) {
+    case "DAILY":
+      // เมื่อวาน
+      return {
+        startDate: startOfDay(subDays(baseDate, 1)),
+        endDate: endOfDay(subDays(baseDate, 1)),
+      };
+
+    case "MONTHLY":
+      // 30 วันก่อนหน้า (วันที่ 31-60 ที่แล้ว)
+      return {
+        startDate: startOfDay(subDays(baseDate, 59)),
+        endDate: endOfDay(subDays(baseDate, 30)),
+      };
+
+    case "YEARLY":
+      // ปีที่แล้ว
+      const lastYear = new Date(baseDate.getFullYear() - 1, 0, 1);
+      return {
+        startDate: startOfYear(lastYear),
+        endDate: endOfYear(lastYear),
+      };
+  }
+}


### PR DESCRIPTION
Introduce a new back-office dashboard page and all supporting modules. Adds app/(back-office)/dashboard/page.tsx (server page with requireOwner and parallel data fetching) and Dashboard UI: period filter (client), sales/appointments/reviews/popular-services cards, and a finance bar chart (client). Implements Drizzle queries for sales, appointments, finance chart data, popular services and review summary, plus dashboard types and a date-range util. Also updates app sidebar to include a Dashboard entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * เพิ่มหน้าแดชบอร์ดภาพรวมธุรกิจพร้อมเมนู "Business Overview" ในแถบนำทาง
  * ตัวกรองช่วงเวลา (รายวัน/รายเดือน/รายปี) พร้อมการโหลดแบบรอและสถานะว่างเมื่อไม่มีข้อมูล
  * บัตรสรุปยอดขายแสดงรายได้รวม จำนวนรายการ และเทรนด์เปรียบเทียบ
  * บัตรสรุปการนัดหมายแสดงยอดรวมและสถานะ (กำลังดำเนินการ, เสร็จสิ้น, ยกเลิก)
  * แผนภูมิการเงินเต็มความกว้างแสดงรายได้ ค่าใช้จ่าย และกำไร/ขาดทุน
  * จัดอันดับบริการยอดนิยมพร้อมจำนวนการใช้งานและรายได้
  * สรุปรีวิวลูกค้าพร้อมคะแนนเฉลี่ย การแจกแจงดาว และความเห็นล่าสุด
<!-- end of auto-generated comment: release notes by coderabbit.ai -->