### PR TITLE
Add shop-closed-day checks for bookings

### DIFF
--- a/app/(back-office)/appointments/create/page.tsx
+++ b/app/(back-office)/appointments/create/page.tsx
@@ -21,7 +21,7 @@ export default async function CreateAppointmentPage() {
     <div>
       <SiteHeader title="เพิ่มนัดหมายใหม่" />
       <div className="p-6">
-        <BackButton />
+        <BackButton className="mb-4" />
         <CreateAppointmentForm services={servicesWithVariants.data} />
       </div>
     </div>

--- a/lib/constants/appointment.ts
+++ b/lib/constants/appointment.ts
@@ -1,1 +1,2 @@
 export const APPOINTMENT_DEPOSIT_AMOUNT = 100;
+export const SHOP_CLOSED_DAY = 3; // 0 = Sunday, 1 = Monday, 2 = Tuesday, 3 = Wednesday, 4 = Thursday, 5 = Friday, 6 = Saturday

--- a/modules/appointment/actions/create-appointment.ts
+++ b/modules/appointment/actions/create-appointment.ts
@@ -7,6 +7,7 @@ import { addMinutes, parseISO, startOfDay } from "date-fns";
 import { revalidatePath } from "next/cache";
 import { ActionResponse } from "@/types/action";
 import { requireStaff } from "@/lib/session";
+import { SHOP_CLOSED_DAY } from "@/lib/constants/appointment";
 
 type PetBookingInput = {
   petId: string;
@@ -21,21 +22,35 @@ export interface CreateMultipleAppointmentInput {
   note?: string;
 }
 
-export async function createAppointment(data: CreateMultipleAppointmentInput): Promise<ActionResponse<{ appointmentId: string }>> {
+export async function createAppointment(
+  data: CreateMultipleAppointmentInput,
+): Promise<ActionResponse<{ appointmentId: string }>> {
   try {
+    const session = await requireStaff({ redirect: false });
 
-    const session = await requireStaff({redirect: false});
-    
     if (!session) {
       return { success: false, error: "คุณไม่มีสิทธิ์ในการดำเนินการนี้" };
     }
 
     if (!data.petBookings || data.petBookings.length === 0) {
-      return { success: false, error: "ไม่พบข้อมูลสัตว์เลี้ยงที่ต้องการรับบริการ" };
+      return {
+        success: false,
+        error: "ไม่พบข้อมูลสัตว์เลี้ยงที่ต้องการรับบริการ",
+      };
     }
 
     const initialStartTime = parseISO(data.startTimeIso);
-    const appointmentDate = startOfDay(initialStartTime); 
+
+    // ใช้แยกส่วน String แล้วประกอบใหม่ด้วย 'Z' (UTC)
+    const dateString = data.startTimeIso.split("T")[0]; // "2026-04-28"
+    const appointmentDate = new Date(`${dateString}T00:00:00Z`); // บังคับเป็น Date object ตาม UTC
+
+    if (appointmentDate.getDay() === SHOP_CLOSED_DAY) {
+      return {
+        success: false,
+        error: "ไม่สามารถจองคิวในวันหยุดของร้านได้",
+      };
+    }
 
     // 1. รวบรวม ID ของ Service Variant ทั้งหมดที่ถูกเรียกใช้ เพื่อนำไปค้นหาราคา
     const allVariantIds = new Set<string>();
@@ -48,7 +63,6 @@ export async function createAppointment(data: CreateMultipleAppointmentInput): P
 
     // 2. เริ่มต้น Database Transaction
     await db.transaction(async (tx) => {
-      
       // 2.1 ดึงข้อมูลราคาและระยะเวลาล่าสุดจากฐานข้อมูล (ป้องกัน Client แก้ไขราคา)
       const selectedVariants = await tx.query.serviceVariants.findMany({
         where: inArray(serviceVariants.id, Array.from(allVariantIds)),
@@ -65,7 +79,7 @@ export async function createAppointment(data: CreateMultipleAppointmentInput): P
         .values({
           appointmentDate: appointmentDate,
           customerId: data.customerId,
-          status: "PENDING_DEPOSIT", 
+          status: "PENDING_DEPOSIT",
           note: data.note || null,
         })
         .returning({ id: appointments.id });
@@ -78,27 +92,38 @@ export async function createAppointment(data: CreateMultipleAppointmentInput): P
 
       for (const booking of data.petBookings) {
         // จัดการบริการหลัก
-        const mainVariant = selectedVariants.find((v) => v.id === booking.mainVariantId);
-        if (!mainVariant) throw new Error(`ไม่พบบริการหลักสำหรับสัตว์เลี้ยงรหัส ${booking.petId}`);
+        const mainVariant = selectedVariants.find(
+          (v) => v.id === booking.mainVariantId,
+        );
+        if (!mainVariant)
+          throw new Error(
+            `ไม่พบบริการหลักสำหรับสัตว์เลี้ยงรหัส ${booking.petId}`,
+          );
 
-        const mainEndTime = addMinutes(currentStartTime, mainVariant.durationMinutes || 0);
+        const mainEndTime = addMinutes(
+          currentStartTime,
+          mainVariant.durationMinutes || 0,
+        );
         itemsToInsert.push({
           appointmentId: newAppointment.id,
           petId: booking.petId,
           serviceVariantId: mainVariant.id,
-          price: mainVariant.minPrice.toString(), 
+          price: mainVariant.minPrice.toString(),
           startTime: currentStartTime,
           endTime: mainEndTime,
         });
-        
-        currentStartTime = mainEndTime; 
+
+        currentStartTime = mainEndTime;
 
         // จัดการบริการเสริม
         if (booking.addOnVariantIds && booking.addOnVariantIds.length > 0) {
           for (const addOnId of booking.addOnVariantIds) {
             const addOnVariant = selectedVariants.find((v) => v.id === addOnId);
             if (addOnVariant) {
-              const addOnEndTime = addMinutes(currentStartTime, addOnVariant.durationMinutes || 0);
+              const addOnEndTime = addMinutes(
+                currentStartTime,
+                addOnVariant.durationMinutes || 0,
+              );
               itemsToInsert.push({
                 appointmentId: newAppointment.id,
                 petId: booking.petId,
@@ -107,8 +132,8 @@ export async function createAppointment(data: CreateMultipleAppointmentInput): P
                 startTime: currentStartTime,
                 endTime: addOnEndTime,
               });
-              
-              currentStartTime = addOnEndTime; 
+
+              currentStartTime = addOnEndTime;
             }
           }
         }
@@ -117,33 +142,42 @@ export async function createAppointment(data: CreateMultipleAppointmentInput): P
       // 2.4 ตรวจสอบ Collision และบันทึกรายการย่อย (Batch Insert)
       if (itemsToInsert.length > 0) {
         // 2.4.1 สร้างเงื่อนไข Overlap Check (เริ่มก่อนจบ และจบหลังเริ่ม)
-        const overlapConditions = itemsToInsert.map(item =>
+        const overlapConditions = itemsToInsert.map((item) =>
           and(
             lt(appointmentItems.startTime, item.endTime),
-            gt(appointmentItems.endTime, item.startTime)
-          )
+            gt(appointmentItems.endTime, item.startTime),
+          ),
         );
 
         // 2.4.2 ดึงข้อมูลและล็อค Row ด้วย FOR UPDATE
         const collisions = await tx
           .select({ id: appointmentItems.id })
           .from(appointmentItems)
-          .innerJoin(appointments, eq(appointmentItems.appointmentId, appointments.id))
+          .innerJoin(
+            appointments,
+            eq(appointmentItems.appointmentId, appointments.id),
+          )
           .where(
             and(
               eq(appointments.appointmentDate, appointmentDate),
               inArray(appointments.status, [
-                "PENDING_DEPOSIT", "PENDING_APPROVAL", "CONFIRMED", 
-                "CHECKED_IN", "IN_PROGRESS", "READY_FOR_PICKUP"
+                "PENDING_DEPOSIT",
+                "PENDING_APPROVAL",
+                "CONFIRMED",
+                "CHECKED_IN",
+                "IN_PROGRESS",
+                "READY_FOR_PICKUP",
               ]), // ละเว้นการตรวจจับคิวที่ถูก CANCELLED หรือ NO_SHOW ไปแล้ว
-              or(...overlapConditions)
-            )
+              or(...overlapConditions),
+            ),
           )
           .for("update");
 
         // 2.4.3 หากเจอทับซ้อน ให้โยน Error เพื่อ Rollback ทันที
         if (collisions.length > 0) {
-          throw new Error("เกิดข้อผิดพลาด: มีบางช่วงเวลาถูกจองไปแล้วในขณะที่คุณกำลังทำรายการ กรุณารีเฟรชและเลือกเวลาใหม่");
+          throw new Error(
+            "เกิดข้อผิดพลาด: มีบางช่วงเวลาถูกจองไปแล้วในขณะที่คุณกำลังทำรายการ กรุณารีเฟรชและเลือกเวลาใหม่",
+          );
         }
 
         // 2.4.4 บันทึกลงฐานข้อมูลหากปลอดภัยจากการทับซ้อน
@@ -158,6 +192,12 @@ export async function createAppointment(data: CreateMultipleAppointmentInput): P
     return { success: true, data: { appointmentId } };
   } catch (error) {
     console.error("Create Appointment Transaction Error:", error);
-    return { success: false, error: error instanceof Error ? error.message : "เกิดข้อผิดพลาดในการบันทึกข้อมูล" };
+    return {
+      success: false,
+      error:
+        error instanceof Error
+          ? error.message
+          : "เกิดข้อผิดพลาดในการบันทึกข้อมูล",
+    };
   }
 }

--- a/modules/appointment/actions/create-appointment.ts
+++ b/modules/appointment/actions/create-appointment.ts
@@ -45,7 +45,7 @@ export async function createAppointment(
     const dateString = data.startTimeIso.split("T")[0]; // "2026-04-28"
     const appointmentDate = new Date(`${dateString}T00:00:00Z`); // บังคับเป็น Date object ตาม UTC
 
-    if (appointmentDate.getDay() === SHOP_CLOSED_DAY) {
+    if (appointmentDate.getUTCDay() === SHOP_CLOSED_DAY) {
       return {
         success: false,
         error: "ไม่สามารถจองคิวในวันหยุดของร้านได้",

--- a/modules/appointment/components/CreateAppointmentForm.tsx
+++ b/modules/appointment/components/CreateAppointmentForm.tsx
@@ -19,6 +19,7 @@ import { getAvailableSlots } from "../queries/get-available-slots";
 import { PET_TYPE_LABELS } from "@/lib/constants/pet-type";
 import { PET_SIZE_LABELS } from "@/lib/constants/service-type";
 import { createAppointment } from "../actions/create-appointment";
+import { SHOP_CLOSED_DAY } from "@/lib/constants/appointment";
 
 // ----------------------------------------------------------------------
 // AvailableSlots Component
@@ -50,15 +51,27 @@ export function AvailableSlots({
   onSelectSlot,
   error,
 }: AvailableSlotsProps) {
-  const [selectedDate, setSelectedDate] = useState<string>(
-    format(new Date(), "yyyy-MM-dd"),
-  );
+  const [selectedDate, setSelectedDate] = useState<string>(() => {
+    // กำหนดค่าเริ่มต้น แต่ไม่ใช่วันหยุดร้าน
+    let date = new Date();
+    while (date.getDay() === SHOP_CLOSED_DAY) {
+      date.setDate(date.getDate() + 1);
+    }
+    return format(date, "yyyy-MM-dd");
+  });
   const [availableSlots, setAvailableSlots] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   useEffect(() => {
     const fetchSlots = async () => {
       if (!selectedDate || durationMinutes <= 0) return;
+      
+      const dayOfWeek = new Date(selectedDate).getDay();
+      if (dayOfWeek === SHOP_CLOSED_DAY) {
+        setAvailableSlots([]);
+        return;
+      }
+
       setIsLoading(true);
       onSelectSlot("");
 
@@ -98,7 +111,17 @@ export function AvailableSlots({
             type="date"
             value={selectedDate}
             min={format(new Date(), "yyyy-MM-dd")}
-            onChange={(e) => setSelectedDate(e.target.value)}
+            onChange={(e) => {
+              const val = e.target.value;
+              if (val) {
+                const day = new Date(val).getDay();
+                if (day === SHOP_CLOSED_DAY) {
+                  toast.error("ไม่สามารถจองคิวในวันหยุดของร้านได้");
+                  return;
+                }
+              }
+              setSelectedDate(val);
+            }}
             className="w-full sm:w-auto"
           />
         </div>

--- a/modules/appointment/queries/get-available-slots.ts
+++ b/modules/appointment/queries/get-available-slots.ts
@@ -12,6 +12,8 @@ import {
   startOfDay,
 } from "date-fns";
 
+import { SHOP_CLOSED_DAY } from "@/lib/constants/appointment";
+
 interface GetSlotsParams {
   date: string;
   durationMinutes: number;
@@ -23,6 +25,11 @@ export async function getAvailableSlots({
 }: GetSlotsParams) {
   try {
     const targetDate = parseISO(date);
+
+    if (targetDate.getDay() === SHOP_CLOSED_DAY) {
+      return { success: true, data: [] };
+    }
+
     const startOfTargetDay = startOfDay(targetDate);
     const endOfTargetDay = addMinutes(startOfTargetDay, 24 * 60 - 1);
 


### PR DESCRIPTION
Introduce SHOP_CLOSED_DAY constant and enforce it across backend, queries and UI. create-appointment now normalizes the appointmentDate to UTC and rejects attempts to create appointments on the shop closed day. get-available-slots returns an empty list for the closed day. The AvailableSlots component defaults to the next non-closed date, prevents selecting the closed day (shows a toast) and hides slots for that day. Also small UI tweak: add margin to BackButton and minor formatting/refactors and error message normalization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * เพิ่มการกำหนดวันปิดร้านเป็นค่าคงที่เพื่อใช้ในส่วนติดต่อผู้ใช้และการตรวจสอบ

* **Bug Fixes**
  * ป้องกันการสร้างการนัดหมายในวันที่ร้านปิด (บล็อกที่ฝั่งเซิร์ฟเวอร์)
  * ปรับพฤติกรรมหน้าจอเลือกวันที่: ไม่อนุญาตให้เลือกวันปิด จะแสดงข้อความแจ้งเตือนและเคลียร์ช่องว่างเวลาที่มีอยู่
  * ปรับระยะห่างของปุ่มย้อนกลับบนหน้าสร้างนัดหมายให้มีมาร์จิ้นด้านล่างเพิ่มเติม
<!-- end of auto-generated comment: release notes by coderabbit.ai -->