### PR TITLE
Add navigation lib and back-office home

### DIFF
--- a/app/(back-office)/back-office/page.tsx
+++ b/app/(back-office)/back-office/page.tsx
@@ -1,0 +1,52 @@
+import Link from "next/link";
+import { requireStaff } from "@/lib/session"; // ปรับ path ให้ตรงกับที่เก็บ function ของคุณ
+import { NAVIGATION_ITEMS, UserRole } from "@/lib/navigation";
+import { Card, CardHeader, CardTitle } from "@/components/ui/card";
+import { SiteHeader } from "@/components/site-header";
+
+export default async function BackOfficeHomePage() {
+  // ดึงข้อมูล Session บน Server ฝั่งเพื่อทำ RBAC
+  const session = await requireStaff();
+  const userRole = session?.user?.role as UserRole;
+  const userName = session?.user?.name || "ผู้ใช้งาน";
+
+  // กรองเมนูตาม Role ของผู้ใช้
+  const quickAccessModules = NAVIGATION_ITEMS.filter(
+    (item) =>
+      item.allowedUserRoles.includes(userRole) && item.url !== "/back-office",
+  );
+
+  return (
+    <>
+      <SiteHeader title="หน้าหลัก" />
+
+      <div className="flex-1 space-y-6 p-8 pt-6">
+        <div className="flex flex-col space-y-2">
+          <h1 className="font-bold text-3xl tracking-tight">
+            ยินดีต้อนรับ, {userName}
+          </h1>
+          <p className="text-muted-foreground">
+            ระบบจัดการร้านอาบน้ำตัดขนสัตว์เลี้ยง กรุณาเลือกเมนูที่คุณต้องการเข้าถึงจากรายการด้านล่าง
+          </p>
+        </div>
+
+        <div className="gap-4 grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+          {quickAccessModules.map((module) => (
+            <Link key={module.url} href={module.url} className="group block">
+              <Card className="hover:bg-muted/50 hover:shadow-sm hover:border-primary/50 h-full transition-all duration-200">
+                <CardHeader className="flex flex-row items-center gap-4 space-y-0 p-6">
+                  <div className="flex justify-center items-center bg-primary/10 group-hover:bg-primary rounded-lg size-10 text-primary group-hover:text-primary-foreground transition-colors">
+                    {module.icon}
+                  </div>
+                  <CardTitle className="font-medium text-base">
+                    {module.title}
+                  </CardTitle>
+                </CardHeader>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -2,19 +2,7 @@
 
 import * as React from "react";
 import Link from "next/link";
-import {
-  UsersIcon,
-  User2Icon,
-  PawPrintIcon,
-  LayoutGridIcon,
-  CalendarClockIcon,
-  ReceiptIcon,
-  ListTodoIcon,
-  PackageIcon,
-  WalletIcon,
-  BarChart3Icon,
-  Loader2,
-} from "lucide-react";
+import { Loader2 } from "lucide-react";
 
 import { NavMain } from "@/components/nav-main";
 import { NavUser } from "@/components/nav-user";
@@ -28,90 +16,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { authClient } from "@/lib/auth-client";
-
-export type UserRole = "owner" | "admin" | "staff" | "customer" | "guest";
-
-interface NavItem {
-  title: string;
-  url: string;
-  icon: React.ReactNode;
-  allowedUserRoles: UserRole[];
-}
-
-const NAVIGATION_ITEMS: NavItem[] = [
-  {
-    title: "ภาพรวมธุรกิจ",
-    url: "/back-office/dashboard",
-    icon: <BarChart3Icon className="size-4" />,
-    allowedUserRoles: ["owner"],
-  },
-  {
-    title: "จัดการผู้ใช้",
-    url: "/back-office/users",
-    icon: <UsersIcon className="size-4" />,
-    allowedUserRoles: ["admin"],
-  },
-  {
-    title: "จัดการลูกค้าและสัตว์เลี้ยง",
-    url: "/back-office/customers",
-    icon: <User2Icon className="size-4" />,
-    allowedUserRoles: ["owner", "admin", "staff"],
-  },
-  {
-    title: "จัดการสายพันธุ์สัตว์เลี้ยง",
-    url: "/back-office/pet-breeds",
-    icon: <PawPrintIcon className="size-4" />,
-    allowedUserRoles: ["owner", "admin", "staff"],
-  },
-  {
-    title: "จัดการบริการ",
-    url: "/back-office/services",
-    icon: <LayoutGridIcon className="size-4" />,
-    allowedUserRoles: ["owner", "admin"],
-  },
-  {
-    title: "จัดการนัดหมาย",
-    url: "/back-office/appointments",
-    icon: <CalendarClockIcon className="size-4" />,
-    allowedUserRoles: ["owner", "admin", "staff"],
-  },
-  {
-    title: "คิวงานประจำวัน",
-    url: "/back-office/operations",
-    icon: <ListTodoIcon className="size-4" />,
-    allowedUserRoles: ["owner", "staff"],
-  },
-  {
-    title: "POS",
-    url: "/back-office/pos",
-    icon: <ReceiptIcon className="size-4" />,
-    allowedUserRoles: ["owner", "admin", "staff"],
-  },
-  {
-    title: "จัดการหมวดหมู่สินค้า",
-    url: "/back-office/inventory-categories",
-    icon: <PackageIcon className="size-4" />,
-    allowedUserRoles: ["owner", "admin", "staff"],
-  },
-  {
-    title: "จัดการสินค้าคงคลัง",
-    url: "/back-office/inventories",
-    icon: <PackageIcon className="size-4" />,
-    allowedUserRoles: ["owner", "admin", "staff"],
-  },
-  {
-    title: "จัดการหมวดหมู่ธุรกรรม",
-    url: "/back-office/transaction-categories",
-    icon: <WalletIcon className="size-4" />,
-    allowedUserRoles: ["owner"],
-  },
-  {
-    title: "จัดการบัญชี",
-    url: "/back-office/accounting",
-    icon: <WalletIcon className="size-4" />,
-    allowedUserRoles: ["owner"],
-  },
-];
+import { NAVIGATION_ITEMS, UserRole } from "@/lib/navigation"; // นำเข้าจาก Config
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
   const { data: session, isPending } = authClient.useSession();
@@ -123,6 +28,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
       item.allowedUserRoles.includes(user.role as UserRole),
     );
   }, [user]);
+
   return (
     <Sidebar collapsible="offcanvas" {...props}>
       <SidebarHeader>
@@ -132,7 +38,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
               asChild
               className="data-[slot=sidebar-menu-button]:p-1.5!"
             >
-              <Link href="/back-office/dashboard">
+              <Link href="/back-office">
                 <span className="font-semibold text-base">PET HOUSE</span>
               </Link>
             </SidebarMenuButton>

--- a/components/nav-main.tsx
+++ b/components/nav-main.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 import {
   SidebarGroup,
@@ -6,21 +6,23 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-} from "@/components/ui/sidebar"
-import Link from "next/link"
-import { usePathname } from "next/navigation"
+} from "@/components/ui/sidebar";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { NavItem } from "@/lib/navigation";
 
 export function NavMain({
   items,
 }: {
-  items: {
-    title: string
-    url: string
-    icon?: React.ReactNode
-  }[]
+  items: Pick<NavItem, "title" | "url" | "icon">[];
 }) {
-  const pathname = usePathname()
-  const isActive = (url: string) => pathname === url || pathname.startsWith(url + "/")
+  const pathname = usePathname();
+  const isActive = (url: string) => {
+    if (url === "/back-office") {
+      return pathname === url;
+    }
+    return pathname.startsWith(url + "/") || pathname === url;
+  };
 
   return (
     <SidebarGroup>
@@ -31,7 +33,11 @@ export function NavMain({
               <SidebarMenuButton
                 tooltip={item.title}
                 asChild
-                className={isActive(item.url) ? "bg-sidebar-accent text-sidebar-accent-foreground" : undefined}
+                className={
+                  isActive(item.url)
+                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                    : undefined
+                }
               >
                 <Link href={item.url}>
                   {item.icon}
@@ -43,5 +49,5 @@ export function NavMain({
         </SidebarMenu>
       </SidebarGroupContent>
     </SidebarGroup>
-  )
+  );
 }

--- a/lib/navigation.tsx
+++ b/lib/navigation.tsx
@@ -1,0 +1,106 @@
+import * as React from "react";
+import {
+  House,
+  LayoutDashboard,
+  UserCog,
+  Users,
+  PawPrint,
+  Scissors,
+  CalendarClock,
+  ClipboardList,
+  Store,
+  Layers,
+  Boxes,
+  Tags,
+  CircleDollarSign,
+} from "lucide-react";
+
+export type UserRole = "owner" | "admin" | "staff" | "customer" | "guest";
+
+export interface NavItem {
+  title: string;
+  url: string;
+  icon: React.ReactNode;
+  allowedUserRoles: UserRole[];
+}
+
+export const NAVIGATION_ITEMS: NavItem[] = [
+  {
+    title: "หน้าหลัก",
+    url: "/back-office",
+    icon: <House className="size-5" />,
+    allowedUserRoles: ["owner", "admin", "staff"],
+  },
+  {
+    title: "ภาพรวมธุรกิจ",
+    url: "/back-office/dashboard",
+    icon: <LayoutDashboard className="size-5" />,
+    allowedUserRoles: ["owner"],
+  },
+  {
+    title: "จัดการผู้ใช้",
+    url: "/back-office/users",
+    icon: <UserCog className="size-5" />,
+    allowedUserRoles: ["admin"],
+  },
+  {
+    title: "จัดการลูกค้าและสัตว์เลี้ยง",
+    url: "/back-office/customers",
+    icon: <Users className="size-5" />,
+    allowedUserRoles: ["owner", "admin", "staff"],
+  },
+  {
+    title: "จัดการสายพันธุ์สัตว์เลี้ยง",
+    url: "/back-office/pet-breeds",
+    icon: <PawPrint className="size-5" />,
+    allowedUserRoles: ["owner", "admin", "staff"],
+  },
+  {
+    title: "จัดการบริการ",
+    url: "/back-office/services",
+    icon: <Scissors className="size-5" />,
+    allowedUserRoles: ["owner", "admin"],
+  },
+  {
+    title: "จัดการนัดหมาย",
+    url: "/back-office/appointments",
+    icon: <CalendarClock className="size-5" />,
+    allowedUserRoles: ["owner", "admin", "staff"],
+  },
+  {
+    title: "คิวงานประจำวัน",
+    url: "/back-office/operations",
+    icon: <ClipboardList className="size-5" />,
+    allowedUserRoles: ["staff"],
+  },
+  {
+    title: "POS",
+    url: "/back-office/pos",
+    icon: <Store className="size-5" />,
+    allowedUserRoles: ["owner", "admin", "staff"],
+  },
+  {
+    title: "จัดการหมวดหมู่สินค้า",
+    url: "/back-office/inventory-categories",
+    icon: <Layers className="size-5" />,
+    allowedUserRoles: ["owner", "admin", "staff"],
+  },
+  {
+    title: "จัดการสินค้าคงคลัง",
+    url: "/back-office/inventories",
+    icon: <Boxes className="size-5" />,
+    allowedUserRoles: ["owner", "admin", "staff"],
+  },
+  {
+    title: "จัดการหมวดหมู่ธุรกรรม",
+    url: "/back-office/transaction-categories",
+    icon: <Tags className="size-5" />,
+    allowedUserRoles: ["owner"],
+  },
+  {
+    title: "จัดการบัญชี",
+    url: "/back-office/accounting",
+    icon: <CircleDollarSign className="size-5" />,
+    allowedUserRoles: ["owner"],
+  },
+];

--- a/modules/auth/components/StaffLogin.tsx
+++ b/modules/auth/components/StaffLogin.tsx
@@ -53,12 +53,7 @@ export function StaffLoginForm() {
         return;
       }
 
-      // TODO: Check role
-      if (resultSignIn.user.role === "admin") {
-        router.push("/back-office/users");
-      } else {
-        router.push("/");
-      }
+      router.push("/back-office");
     } catch (error) {
       console.error("Login Error:", error);
       toast.error("เกิดข้อผิดพลาดในการเข้าสู่ระบบ");

--- a/modules/auth/components/StaffLogin.tsx
+++ b/modules/auth/components/StaffLogin.tsx
@@ -53,7 +53,17 @@ export function StaffLoginForm() {
         return;
       }
 
-      router.push("/back-office");
+      // Get session to check user role
+      const { data: session } = await authClient.getSession();
+      const userRole = session?.user?.role;
+
+      // Redirect based on user role
+      if (userRole === "admin" || userRole === "staff" || userRole === "owner") {
+        router.push("/back-office");
+      } else {
+        // For customer or other roles, redirect to home page
+        router.push("/");
+      }
     } catch (error) {
       console.error("Login Error:", error);
       toast.error("เกิดข้อผิดพลาดในการเข้าสู่ระบบ");

--- a/modules/auth/components/StaffLogin.tsx
+++ b/modules/auth/components/StaffLogin.tsx
@@ -53,9 +53,7 @@ export function StaffLoginForm() {
         return;
       }
 
-      // Get session to check user role
-      const { data: session } = await authClient.getSession();
-      const userRole = session?.user?.role;
+      const userRole = resultSignIn?.user?.role;
 
       // Redirect based on user role
       if (userRole === "admin" || userRole === "staff" || userRole === "owner") {


### PR DESCRIPTION
Introduce lib/navigation.tsx which centralizes NAVIGATION_ITEMS and UserRole types (icons + allowed roles). Add a server-side back-office home page (app/(back-office)/back-office/page.tsx) that requires staff session and renders role-filtered quick-access cards. Refactor components to use the new navigation config: remove inline nav definitions from components/app-sidebar.tsx, import NAVIGATION_ITEMS/UserRole there, and adjust the sidebar brand link to /back-office. Improve NavMain typing and isActive logic, clean up imports/formatting, and change StaffLogin redirect to point to /back-office after sign-in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## การปล่อยรุ่นใหม่

* **ฟีเจอร์ใหม่**
  * เพิ่มหน้าแรกแบ็กออฟฟิศที่แสดงโมดูลเป็นการ์ดแบบตอบสนองตามบทบาทผู้ใช้

* **ปรับปรุง**
  * รวบรวมและจัดการรายการนำทางแบบศูนย์กลางเพื่อความสอดคล้องของเมนูและการกรองตามบทบาท
  * ปรับพฤติกรรมแถบนำทางให้ตรวจสอบสถานะ “active” อย่างถูกต้องสำหรับเส้นทางหลัก
  * ปรับเส้นทางหลังล็อกอินของเจ้าหน้าที่: ผู้ดูแล/เจ้าหน้าที่/เจ้าของไปยังแบ็กออฟฟิศ คนอื่นไปหน้าหลัก
<!-- end of auto-generated comment: release notes by coderabbit.ai -->