### PR TITLE
refactor(ui): reuse table action buttons

### DIFF
--- a/components/shared/TableActionButton.tsx
+++ b/components/shared/TableActionButton.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import {
+  BanIcon,
+  CircleCheckIcon,
+  EyeIcon,
+  Loader2Icon,
+  PencilIcon,
+  SettingsIcon,
+  TrashIcon,
+  type LucideIcon,
+} from "lucide-react";
+import Link from "next/link";
+import type * as React from "react";
+
+type TableActionButtonProps = Omit<
+  React.ComponentProps<typeof Button>,
+  "children"
+> & {
+  icon: LucideIcon;
+  isLoading?: boolean;
+};
+
+type TableActionLinkProps = Omit<
+  React.ComponentProps<typeof Button>,
+  "asChild" | "children" | "onClick"
+> & {
+  href: string;
+  icon: LucideIcon;
+};
+
+export const TABLE_ACTION_ICONS = {
+  ban: BanIcon,
+  delete: TrashIcon,
+  edit: PencilIcon,
+  manage: SettingsIcon,
+  unban: CircleCheckIcon,
+  view: EyeIcon,
+} as const satisfies Record<string, LucideIcon>;
+
+function ActionIcon({
+  icon: Icon,
+  isLoading,
+}: {
+  icon: LucideIcon;
+  isLoading?: boolean;
+}) {
+  const IconComponent = isLoading ? Loader2Icon : Icon;
+
+  return (
+    <IconComponent
+      data-icon="inline-start"
+      className={isLoading ? "animate-spin" : undefined}
+    />
+  );
+}
+
+export function TableActionButton({
+  icon,
+  isLoading,
+  size = "icon",
+  variant = "outline",
+  ...props
+}: TableActionButtonProps) {
+  return (
+    <Button variant={variant} size={size} {...props}>
+      <ActionIcon icon={icon} isLoading={isLoading} />
+    </Button>
+  );
+}
+
+export function TableActionLink({
+  href,
+  icon,
+  size = "icon",
+  variant = "outline",
+  ...props
+}: TableActionLinkProps) {
+  return (
+    <Button variant={variant} size={size} asChild {...props}>
+      <Link href={href}>
+        <ActionIcon icon={icon} />
+      </Link>
+    </Button>
+  );
+}

--- a/components/shared/TableActionButton.tsx
+++ b/components/shared/TableActionButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import {
   BanIcon,
   CircleCheckIcon,
@@ -14,11 +15,14 @@ import {
 import Link from "next/link";
 import type * as React from "react";
 
+type TableAction = "ban" | "delete" | "edit" | "manage" | "unban" | "view";
+
 type TableActionButtonProps = Omit<
   React.ComponentProps<typeof Button>,
   "children"
 > & {
-  icon: LucideIcon;
+  action: TableAction;
+  icon?: LucideIcon;
   isLoading?: boolean;
 };
 
@@ -26,8 +30,9 @@ type TableActionLinkProps = Omit<
   React.ComponentProps<typeof Button>,
   "asChild" | "children" | "onClick"
 > & {
+  action: TableAction;
   href: string;
-  icon: LucideIcon;
+  icon?: LucideIcon;
 };
 
 export const TABLE_ACTION_ICONS = {
@@ -38,6 +43,45 @@ export const TABLE_ACTION_ICONS = {
   unban: CircleCheckIcon,
   view: EyeIcon,
 } as const satisfies Record<string, LucideIcon>;
+
+export const TABLE_ACTION_CONFIG = {
+  ban: {
+    icon: TABLE_ACTION_ICONS.ban,
+    className:
+      "border-destructive/20 bg-destructive/10 text-destructive hover:bg-destructive/20 hover:text-destructive focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30",
+  },
+  delete: {
+    icon: TABLE_ACTION_ICONS.delete,
+    className:
+      "border-destructive/20 bg-destructive/10 text-destructive hover:bg-destructive/20 hover:text-destructive focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30",
+  },
+  edit: {
+    icon: TABLE_ACTION_ICONS.edit,
+    className:
+      "border-primary/20 bg-primary/10 text-primary hover:bg-primary/20 hover:text-primary focus-visible:border-primary/40 focus-visible:ring-primary/20",
+  },
+  manage: {
+    icon: TABLE_ACTION_ICONS.manage,
+    className:
+      "border-border bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:text-secondary-foreground",
+  },
+  unban: {
+    icon: TABLE_ACTION_ICONS.unban,
+    className:
+      "border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 hover:text-emerald-800 focus-visible:border-emerald-400 focus-visible:ring-emerald-500/20 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-400 dark:hover:bg-emerald-900/50",
+  },
+  view: {
+    icon: TABLE_ACTION_ICONS.view,
+    className:
+      "border-border bg-secondary text-secondary-foreground hover:bg-secondary/80 hover:text-secondary-foreground",
+  },
+} as const satisfies Record<
+  TableAction,
+  {
+    icon: LucideIcon;
+    className: string;
+  }
+>;
 
 function ActionIcon({
   icon: Icon,
@@ -57,30 +101,49 @@ function ActionIcon({
 }
 
 export function TableActionButton({
+  action,
+  className,
   icon,
   isLoading,
   size = "icon",
   variant = "outline",
   ...props
 }: TableActionButtonProps) {
+  const config = TABLE_ACTION_CONFIG[action];
+
   return (
-    <Button variant={variant} size={size} {...props}>
-      <ActionIcon icon={icon} isLoading={isLoading} />
+    <Button
+      variant={variant}
+      size={size}
+      className={cn(config.className, className)}
+      {...props}
+    >
+      <ActionIcon icon={icon ?? config.icon} isLoading={isLoading} />
     </Button>
   );
 }
 
 export function TableActionLink({
+  action,
+  className,
   href,
   icon,
   size = "icon",
   variant = "outline",
   ...props
 }: TableActionLinkProps) {
+  const config = TABLE_ACTION_CONFIG[action];
+
   return (
-    <Button variant={variant} size={size} asChild {...props}>
+    <Button
+      variant={variant}
+      size={size}
+      className={cn(config.className, className)}
+      asChild
+      {...props}
+    >
       <Link href={href}>
-        <ActionIcon icon={icon} />
+        <ActionIcon icon={icon ?? config.icon} />
       </Link>
     </Button>
   );

--- a/modules/auth/components/UserManagement.tsx
+++ b/modules/auth/components/UserManagement.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import {
-  TableActionButton,
-  TABLE_ACTION_ICONS,
-} from "@/components/shared/TableActionButton";
+import { TableActionButton } from "@/components/shared/TableActionButton";
 import {
   Table,
   TableBody,
@@ -112,13 +109,13 @@ export default function UserManagement({ users }: { users: AuthUser[] }) {
                       {user.banned ? (
                         <TableActionButton
                           aria-label="ยกเลิกการแบน"
-                          icon={TABLE_ACTION_ICONS.unban}
+                          action="unban"
                           onClick={() => unbanUser(user.id)}
                         />
                       ) : (
                         <TableActionButton
                           aria-label="แบนผู้ใช้"
-                          icon={TABLE_ACTION_ICONS.ban}
+                          action="ban"
                           onClick={() => {
                             setSelectedUserId(user.id);
                             setIsBanUserDialogOpen(true);
@@ -128,7 +125,7 @@ export default function UserManagement({ users }: { users: AuthUser[] }) {
 
                       <TableActionButton
                         aria-label="แก้ไขข้อมูล"
-                        icon={TABLE_ACTION_ICONS.edit}
+                        action="edit"
                         disabled={loadingUserId === user.id}
                         isLoading={loadingUserId === user.id}
                         onClick={() => handleEditUser(user.id)}

--- a/modules/auth/components/UserManagement.tsx
+++ b/modules/auth/components/UserManagement.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
+import {
+  TableActionButton,
+  TABLE_ACTION_ICONS,
+} from "@/components/shared/TableActionButton";
 import {
   Table,
   TableBody,
@@ -12,7 +15,6 @@ import {
 
 import { BannedBadge } from "./BannedBadge";
 import { RoleBadge } from "./RoleBadge";
-import { Ban, CircleCheck, Loader2Icon, PencilIcon } from "lucide-react";
 import { AuthUser, AuthUserWithProfile } from "../types/user";
 
 import BanUserDialog from "./BanUserDialog";
@@ -76,11 +78,8 @@ export default function UserManagement({ users }: { users: AuthUser[] }) {
 
   return (
     <>
-      <div className="justify-between items-center gap-3 grid grid-cols-2 mb-5">
-        <div className="flex items-center gap-3"></div>
-        <div className="flex justify-end">
-          <CreateUserDialog />
-        </div>
+      <div className="flex justify-end mb-5">
+        <CreateUserDialog />
       </div>
 
       <div className="border rounded-md overflow-x-auto">
@@ -111,41 +110,29 @@ export default function UserManagement({ users }: { users: AuthUser[] }) {
                   <TableCell className="text-right">
                     <div className="flex justify-end gap-2">
                       {user.banned ? (
-                        <Button
-                          variant="outline"
-                          size="icon"
+                        <TableActionButton
                           aria-label="ยกเลิกการแบน"
+                          icon={TABLE_ACTION_ICONS.unban}
                           onClick={() => unbanUser(user.id)}
-                        >
-                          <CircleCheck className="size-3.5" />
-                        </Button>
+                        />
                       ) : (
-                        <Button
-                          variant="outline"
-                          size="icon"
+                        <TableActionButton
                           aria-label="แบนผู้ใช้"
+                          icon={TABLE_ACTION_ICONS.ban}
                           onClick={() => {
                             setSelectedUserId(user.id);
                             setIsBanUserDialogOpen(true);
                           }}
-                        >
-                          <Ban className="size-3.5" />
-                        </Button>
+                        />
                       )}
 
-                      <Button
-                        variant="outline"
-                        size="icon"
+                      <TableActionButton
                         aria-label="แก้ไขข้อมูล"
+                        icon={TABLE_ACTION_ICONS.edit}
                         disabled={loadingUserId === user.id}
+                        isLoading={loadingUserId === user.id}
                         onClick={() => handleEditUser(user.id)}
-                      >
-                        {loadingUserId === user.id ? (
-                          <Loader2Icon className="size-3.5 animate-spin" />
-                        ) : (
-                          <PencilIcon className="size-3.5" />
-                        )}
-                      </Button>
+                      />
                     </div>
                   </TableCell>
                 </TableRow>

--- a/modules/customer/components/CustomerManagement.tsx
+++ b/modules/customer/components/CustomerManagement.tsx
@@ -8,15 +8,17 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { EyeIcon, PencilIcon, TrashIcon } from "lucide-react";
 import { CreateCustomerDialog } from "@/modules/customer/components/CreateCustomerDialog";
 import { Customer } from "../types/customer";
-import { Button } from "@/components/ui/button";
+import {
+  TableActionButton,
+  TableActionLink,
+  TABLE_ACTION_ICONS,
+} from "@/components/shared/TableActionButton";
 import { UpdateCustomerDialog } from "./UpdateCustomerDialog";
 import { useState } from "react";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { deleteCustomer } from "../actions/delete-customer";
-import Link from "next/link";
 
 interface CustomerManagementProps {
   customers: Customer[];
@@ -63,44 +65,35 @@ export default function CustomerManagement({
                   <TableCell>
                     {new Date(customer.createdAt).toLocaleDateString("th-TH")}
                   </TableCell>
-                  <TableCell className="space-x-2 text-right">
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
                     {/* ดูรายละเอียดลูกค้า */}
-                    <Button
-                      variant="outline"
-                      size="icon"
+                    <TableActionLink
                       aria-label="ดูรายละเอียด"
-                      asChild
-                    >
-                      <Link href={`/back-office/customers/${customer.id}`}>
-                        <EyeIcon className="size-3.5" />
-                      </Link>
-                    </Button>
+                      href={`/back-office/customers/${customer.id}`}
+                      icon={TABLE_ACTION_ICONS.view}
+                    />
 
                     {/* แก้ไขข้อมูลลูกค้า */}
-                    <Button
-                      variant="outline"
-                      size="icon"
+                    <TableActionButton
                       aria-label="แก้ไขข้อมูล"
+                      icon={TABLE_ACTION_ICONS.edit}
                       onClick={() => {
                         setSelectedCustomer(customer);
                         setIsUpdateDialogOpen(true);
                       }}
-                    >
-                      <PencilIcon className="size-3.5" />
-                    </Button>
+                    />
 
                     {/* ลบข้อมูลลูกค้า */}
-                    <Button
-                      variant="outline"
-                      size="icon"
+                    <TableActionButton
                       aria-label="ลบข้อมูล"
+                      icon={TABLE_ACTION_ICONS.delete}
                       onClick={() => {
                         setSelectedCustomer(customer);
                         setIsDeleteDialogOpen(true);
                       }}
-                    >
-                      <TrashIcon className="size-3.5" />
-                    </Button>
+                    />
+                    </div>
                   </TableCell>
                 </TableRow>
               ))

--- a/modules/customer/components/CustomerManagement.tsx
+++ b/modules/customer/components/CustomerManagement.tsx
@@ -13,7 +13,6 @@ import { Customer } from "../types/customer";
 import {
   TableActionButton,
   TableActionLink,
-  TABLE_ACTION_ICONS,
 } from "@/components/shared/TableActionButton";
 import { UpdateCustomerDialog } from "./UpdateCustomerDialog";
 import { useState } from "react";
@@ -70,14 +69,14 @@ export default function CustomerManagement({
                     {/* ดูรายละเอียดลูกค้า */}
                     <TableActionLink
                       aria-label="ดูรายละเอียด"
+                      action="view"
                       href={`/back-office/customers/${customer.id}`}
-                      icon={TABLE_ACTION_ICONS.view}
                     />
 
                     {/* แก้ไขข้อมูลลูกค้า */}
                     <TableActionButton
                       aria-label="แก้ไขข้อมูล"
-                      icon={TABLE_ACTION_ICONS.edit}
+                      action="edit"
                       onClick={() => {
                         setSelectedCustomer(customer);
                         setIsUpdateDialogOpen(true);
@@ -87,7 +86,7 @@ export default function CustomerManagement({
                     {/* ลบข้อมูลลูกค้า */}
                     <TableActionButton
                       aria-label="ลบข้อมูล"
-                      icon={TABLE_ACTION_ICONS.delete}
+                      action="delete"
                       onClick={() => {
                         setSelectedCustomer(customer);
                         setIsDeleteDialogOpen(true);

--- a/modules/inventories/components/InventoriesClient.tsx
+++ b/modules/inventories/components/InventoriesClient.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import {
+  TableActionButton,
+  TABLE_ACTION_ICONS,
+} from "@/components/shared/TableActionButton";
 import { Card, CardDescription, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
@@ -12,7 +15,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { PencilIcon, TrashIcon } from "lucide-react";
 import { useMemo, useState } from "react";
 import { InventoryItem } from "../types/inventory";
 import { InventoryCategory } from "@/modules/inventory-category/types/inventory-category";
@@ -192,29 +194,25 @@ export function InventoriesClient({
                   <TableCell className="text-center">
                     {getStatusBadge(product)}
                   </TableCell>
-                  <TableCell className="space-x-2 text-right">
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      aria-label="แก้ไขข้อมูล"
-                      onClick={() => {
-                        setSelectedInventory(product);
-                        setIsUpdateDialogOpen(true);
-                      }}
-                    >
-                      <PencilIcon className="size-3.5" />
-                    </Button>
-                    <Button
-                      variant="outline"
-                      size="icon"
-                      aria-label="ลบข้อมูล"
-                      onClick={() => {
-                        setSelectedInventory(product);
-                        setIsDeleteDialogOpen(true);
-                      }}
-                    >
-                      <TrashIcon className="size-3.5" />
-                    </Button>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
+                      <TableActionButton
+                        aria-label="แก้ไขข้อมูล"
+                        icon={TABLE_ACTION_ICONS.edit}
+                        onClick={() => {
+                          setSelectedInventory(product);
+                          setIsUpdateDialogOpen(true);
+                        }}
+                      />
+                      <TableActionButton
+                        aria-label="ลบข้อมูล"
+                        icon={TABLE_ACTION_ICONS.delete}
+                        onClick={() => {
+                          setSelectedInventory(product);
+                          setIsDeleteDialogOpen(true);
+                        }}
+                      />
+                    </div>
                   </TableCell>
                 </TableRow>
               ))

--- a/modules/inventories/components/InventoriesClient.tsx
+++ b/modules/inventories/components/InventoriesClient.tsx
@@ -1,10 +1,7 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
-import {
-  TableActionButton,
-  TABLE_ACTION_ICONS,
-} from "@/components/shared/TableActionButton";
+import { TableActionButton } from "@/components/shared/TableActionButton";
 import { Card, CardDescription, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import {
@@ -198,7 +195,7 @@ export function InventoriesClient({
                     <div className="flex justify-end gap-2">
                       <TableActionButton
                         aria-label="แก้ไขข้อมูล"
-                        icon={TABLE_ACTION_ICONS.edit}
+                        action="edit"
                         onClick={() => {
                           setSelectedInventory(product);
                           setIsUpdateDialogOpen(true);
@@ -206,7 +203,7 @@ export function InventoriesClient({
                       />
                       <TableActionButton
                         aria-label="ลบข้อมูล"
-                        icon={TABLE_ACTION_ICONS.delete}
+                        action="delete"
                         onClick={() => {
                           setSelectedInventory(product);
                           setIsDeleteDialogOpen(true);

--- a/modules/inventories/components/PurchaseOrdersPage.tsx
+++ b/modules/inventories/components/PurchaseOrdersPage.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { PlusIcon, Trash2, Eye } from "lucide-react";
+import { PlusIcon } from "lucide-react";
+import {
+  TableActionButton,
+  TableActionLink,
+  TABLE_ACTION_ICONS,
+} from "@/components/shared/TableActionButton";
 import {
   Table,
   TableBody,
@@ -121,32 +126,22 @@ export default function PurchaseOrdersPage({
                     <TableCell className="text-right">
                       <div className="flex justify-end items-center gap-1">
                         {/* ปุ่มดูรายละเอียด */}
-                        <Button
-                          variant="outline"
-                          size="icon"
+                        <TableActionLink
                           aria-label="ดูรายละเอียดใบสั่งซื้อ"
-                          asChild
-                        >
-                          <Link
-                            href={`/back-office/inventories/purchase-orders/${order.id}`}
-                          >
-                            <Eye className="size-3.5" />
-                          </Link>
-                        </Button>
+                          href={`/back-office/inventories/purchase-orders/${order.id}`}
+                          icon={TABLE_ACTION_ICONS.view}
+                        />
 
                         {/* ปุ่มลบ (เฉพาะ DRAFT) */}
                         {order.status === "DRAFT" ? (
-                          <Button
-                            variant="outline"
-                            size="icon"
+                          <TableActionButton
                             aria-label="ลบใบสั่งซื้อ"
+                            icon={TABLE_ACTION_ICONS.delete}
                             onClick={() => {
                               setDeleteTarget(order);
                               setIsDeleteDialogOpen(true);
                             }}
-                          >
-                            <Trash2 className="size-3.5" />
-                          </Button>
+                          />
                         ) : null}
                       </div>
                     </TableCell>

--- a/modules/inventories/components/PurchaseOrdersPage.tsx
+++ b/modules/inventories/components/PurchaseOrdersPage.tsx
@@ -5,7 +5,6 @@ import { PlusIcon } from "lucide-react";
 import {
   TableActionButton,
   TableActionLink,
-  TABLE_ACTION_ICONS,
 } from "@/components/shared/TableActionButton";
 import {
   Table,
@@ -128,15 +127,15 @@ export default function PurchaseOrdersPage({
                         {/* ปุ่มดูรายละเอียด */}
                         <TableActionLink
                           aria-label="ดูรายละเอียดใบสั่งซื้อ"
+                          action="view"
                           href={`/back-office/inventories/purchase-orders/${order.id}`}
-                          icon={TABLE_ACTION_ICONS.view}
                         />
 
                         {/* ปุ่มลบ (เฉพาะ DRAFT) */}
                         {order.status === "DRAFT" ? (
                           <TableActionButton
                             aria-label="ลบใบสั่งซื้อ"
-                            icon={TABLE_ACTION_ICONS.delete}
+                            action="delete"
                             onClick={() => {
                               setDeleteTarget(order);
                               setIsDeleteDialogOpen(true);

--- a/modules/inventory-category/components/InventoryCategoryManagement.tsx
+++ b/modules/inventory-category/components/InventoryCategoryManagement.tsx
@@ -8,8 +8,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { PencilIcon, TrashIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import {
+  TableActionButton,
+  TABLE_ACTION_ICONS,
+} from "@/components/shared/TableActionButton";
 import { useState } from "react";
 import { CreateInventoryCategoryDialog } from "./CreateInventoryCategoryDialog";
 import { InventoryCategory } from "../types/inventory-category";
@@ -48,32 +50,28 @@ export function InventoryCategoryManagement({
               inventoryCategories.map((category) => (
                 <TableRow key={category.id}>
                   <TableCell>{category.name}</TableCell>
-                  <TableCell className="space-x-2 text-right">
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
                     {/* แก้ไขข้อมูลหมวดหมู่ */}
-                    <Button
-                      variant="outline"
-                      size="icon"
+                    <TableActionButton
                       aria-label="แก้ไขข้อมูล"
+                      icon={TABLE_ACTION_ICONS.edit}
                       onClick={() => {
                         setSelectedInventoryCategory(category);
                         setIsUpdateDialogOpen(true);
                       }}
-                    >
-                      <PencilIcon className="size-3.5" />
-                    </Button>
+                    />
 
                     {/* ลบข้อมูลหมวดหมู่ */}
-                    <Button
-                      variant="outline"
-                      size="icon"
+                    <TableActionButton
                       aria-label="ลบข้อมูล"
+                      icon={TABLE_ACTION_ICONS.delete}
                       onClick={() => {
                         setSelectedInventoryCategory(category);
                         setIsDeleteDialogOpen(true);
                       }}
-                    >
-                      <TrashIcon className="size-3.5" />
-                    </Button>
+                    />
+                    </div>
                   </TableCell>
                 </TableRow>
               ))

--- a/modules/inventory-category/components/InventoryCategoryManagement.tsx
+++ b/modules/inventory-category/components/InventoryCategoryManagement.tsx
@@ -8,10 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  TableActionButton,
-  TABLE_ACTION_ICONS,
-} from "@/components/shared/TableActionButton";
+import { TableActionButton } from "@/components/shared/TableActionButton";
 import { useState } from "react";
 import { CreateInventoryCategoryDialog } from "./CreateInventoryCategoryDialog";
 import { InventoryCategory } from "../types/inventory-category";
@@ -55,7 +52,7 @@ export function InventoryCategoryManagement({
                     {/* แก้ไขข้อมูลหมวดหมู่ */}
                     <TableActionButton
                       aria-label="แก้ไขข้อมูล"
-                      icon={TABLE_ACTION_ICONS.edit}
+                      action="edit"
                       onClick={() => {
                         setSelectedInventoryCategory(category);
                         setIsUpdateDialogOpen(true);
@@ -65,7 +62,7 @@ export function InventoryCategoryManagement({
                     {/* ลบข้อมูลหมวดหมู่ */}
                     <TableActionButton
                       aria-label="ลบข้อมูล"
-                      icon={TABLE_ACTION_ICONS.delete}
+                      action="delete"
                       onClick={() => {
                         setSelectedInventoryCategory(category);
                         setIsDeleteDialogOpen(true);

--- a/modules/pet-breed/components/PetBreedManagement.tsx
+++ b/modules/pet-breed/components/PetBreedManagement.tsx
@@ -8,8 +8,10 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { PencilIcon, TrashIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import {
+  TableActionButton,
+  TABLE_ACTION_ICONS,
+} from "@/components/shared/TableActionButton";
 import { useState } from "react";
 import { PET_TYPE_LABELS } from "@/lib/constants/pet-type";
 import { CreatePetBreedDialog } from "./CreatePetBreedDialog";
@@ -50,32 +52,28 @@ export function PetBreedManagement({ petBreeds }: { petBreeds: PetBreed[] }) {
                   <TableCell>
                     {PET_TYPE_LABELS[petBreed.type] || "อื่นๆ"}
                   </TableCell>
-                  <TableCell className="space-x-2 text-right">
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
                     {/* แก้ไขข้อมูลสายพันธุ์ */}
-                    <Button
-                      variant="outline"
-                      size="icon"
+                    <TableActionButton
                       aria-label="แก้ไขข้อมูล"
+                      icon={TABLE_ACTION_ICONS.edit}
                       onClick={() => {
                         setSelectedPetBreed(petBreed);
                         setIsUpdateDialogOpen(true);
                       }}
-                    >
-                      <PencilIcon className="size-3.5" />
-                    </Button>
+                    />
 
                     {/* ลบข้อมูลสายพันธุ์ */}
-                    <Button
-                      variant="outline"
-                      size="icon"
+                    <TableActionButton
                       aria-label="ลบข้อมูล"
+                      icon={TABLE_ACTION_ICONS.delete}
                       onClick={() => {
                         setSelectedPetBreed(petBreed);
                         setIsDeleteDialogOpen(true);
                       }}
-                    >
-                      <TrashIcon className="size-3.5" />
-                    </Button>
+                    />
+                    </div>
                   </TableCell>
                 </TableRow>
               ))

--- a/modules/pet-breed/components/PetBreedManagement.tsx
+++ b/modules/pet-breed/components/PetBreedManagement.tsx
@@ -8,10 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  TableActionButton,
-  TABLE_ACTION_ICONS,
-} from "@/components/shared/TableActionButton";
+import { TableActionButton } from "@/components/shared/TableActionButton";
 import { useState } from "react";
 import { PET_TYPE_LABELS } from "@/lib/constants/pet-type";
 import { CreatePetBreedDialog } from "./CreatePetBreedDialog";
@@ -57,7 +54,7 @@ export function PetBreedManagement({ petBreeds }: { petBreeds: PetBreed[] }) {
                     {/* แก้ไขข้อมูลสายพันธุ์ */}
                     <TableActionButton
                       aria-label="แก้ไขข้อมูล"
-                      icon={TABLE_ACTION_ICONS.edit}
+                      action="edit"
                       onClick={() => {
                         setSelectedPetBreed(petBreed);
                         setIsUpdateDialogOpen(true);
@@ -67,7 +64,7 @@ export function PetBreedManagement({ petBreeds }: { petBreeds: PetBreed[] }) {
                     {/* ลบข้อมูลสายพันธุ์ */}
                     <TableActionButton
                       aria-label="ลบข้อมูล"
-                      icon={TABLE_ACTION_ICONS.delete}
+                      action="delete"
                       onClick={() => {
                         setSelectedPetBreed(petBreed);
                         setIsDeleteDialogOpen(true);

--- a/modules/service/components/ServiceManagement.tsx
+++ b/modules/service/components/ServiceManagement.tsx
@@ -8,8 +8,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { PencilIcon, Settings, TrashIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import {
+  TableActionButton,
+  TableActionLink,
+  TABLE_ACTION_ICONS,
+} from "@/components/shared/TableActionButton";
 import { useState } from "react";
 import { SERVICE_TYPE_LABELS } from "@/lib/constants/service-type";
 import { CreateServiceDialog } from "./CreateServiceDialog";
@@ -17,7 +20,6 @@ import { Service } from "../types/service";
 import { UpdateServiceDialog } from "./UpdateServiceDialog";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 import { deleteService } from "../actions/delete-service";
-import Link from "next/link";
 
 interface ServiceManagementProps {
   services: Service[];
@@ -56,44 +58,35 @@ export default function ServiceManagement({ services }: ServiceManagementProps) 
                     {SERVICE_TYPE_LABELS[service.serviceType] || "อื่นๆ"}
                   </TableCell>
                   <TableCell>{service.description || "-"}</TableCell>
-                  <TableCell className="space-x-2 text-right">
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
                     {/* จัดการตัวเลือกบริการ */}
-                    <Button
-                      variant="outline"
-                      size="icon"
+                    <TableActionLink
                       aria-label="จัดการตัวเลือกบริการ"
-                      asChild
-                    >
-                      <Link href={`/back-office/services/${service.id}/variants`}>
-                        <Settings />
-                      </Link>
-                    </Button>
+                      href={`/back-office/services/${service.id}/variants`}
+                      icon={TABLE_ACTION_ICONS.manage}
+                    />
 
                     {/* แก้ไขข้อมูลบริการ */}
-                    <Button
-                      variant="outline"
-                      size="icon"
+                    <TableActionButton
                       aria-label="แก้ไขข้อมูล"
+                      icon={TABLE_ACTION_ICONS.edit}
                       onClick={() => {
                         setSelectedService(service);
                         setIsEditDialogOpen(true);
                       }}
-                    >
-                      <PencilIcon className="size-3.5" />
-                    </Button>
+                    />
 
                     {/* ลบข้อมูลบริการ */}
-                    <Button
-                      variant="outline"
-                      size="icon"
+                    <TableActionButton
                       aria-label="ลบข้อมูล"
+                      icon={TABLE_ACTION_ICONS.delete}
                       onClick={() => {
                         setSelectedService(service);
                         setIsDeleteDialogOpen(true);
                       }}
-                    >
-                      <TrashIcon className="size-3.5" />
-                    </Button>
+                    />
+                    </div>
                   </TableCell>
                 </TableRow>
               ))

--- a/modules/service/components/ServiceManagement.tsx
+++ b/modules/service/components/ServiceManagement.tsx
@@ -11,7 +11,6 @@ import {
 import {
   TableActionButton,
   TableActionLink,
-  TABLE_ACTION_ICONS,
 } from "@/components/shared/TableActionButton";
 import { useState } from "react";
 import { SERVICE_TYPE_LABELS } from "@/lib/constants/service-type";
@@ -63,14 +62,14 @@ export default function ServiceManagement({ services }: ServiceManagementProps) 
                     {/* จัดการตัวเลือกบริการ */}
                     <TableActionLink
                       aria-label="จัดการตัวเลือกบริการ"
+                      action="manage"
                       href={`/back-office/services/${service.id}/variants`}
-                      icon={TABLE_ACTION_ICONS.manage}
                     />
 
                     {/* แก้ไขข้อมูลบริการ */}
                     <TableActionButton
                       aria-label="แก้ไขข้อมูล"
-                      icon={TABLE_ACTION_ICONS.edit}
+                      action="edit"
                       onClick={() => {
                         setSelectedService(service);
                         setIsEditDialogOpen(true);
@@ -80,7 +79,7 @@ export default function ServiceManagement({ services }: ServiceManagementProps) 
                     {/* ลบข้อมูลบริการ */}
                     <TableActionButton
                       aria-label="ลบข้อมูล"
-                      icon={TABLE_ACTION_ICONS.delete}
+                      action="delete"
                       onClick={() => {
                         setSelectedService(service);
                         setIsDeleteDialogOpen(true);

--- a/modules/service/components/ServiceVariantManagement.tsx
+++ b/modules/service/components/ServiceVariantManagement.tsx
@@ -8,10 +8,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { PencilIcon, TrashIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import {
+  TableActionButton,
+  TABLE_ACTION_ICONS,
+} from "@/components/shared/TableActionButton";
 import { useState } from "react";
-import Link from "next/link";
 import { PET_TYPE_LABELS } from "@/lib/constants/pet-type";
 import { PET_SIZE_LABELS } from "@/lib/constants/service-type";
 import { CreateServiceVariantDialog } from "./CreateServiceVariantDialog";
@@ -69,32 +70,28 @@ export default function ServiceVariantsManagement({
                       : `${variant.minPrice} - ${variant.maxPrice}`}
                   </TableCell>
                   <TableCell>{variant.durationMinutes}</TableCell>
-                  <TableCell className="space-x-2 text-right">
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
                     {/* แก้ไขข้อมูลตัวเลือกบริการ */}
-                    <Button
-                      variant="outline"
-                      size="icon"
+                    <TableActionButton
                       aria-label="แก้ไขข้อมูล"
+                      icon={TABLE_ACTION_ICONS.edit}
                       onClick={() => {
                         setSelectedVariant(variant);
                         setIsEditDialogOpen(true);
                       }}
-                    >
-                      <PencilIcon className="size-3.5" />
-                    </Button>
+                    />
 
                     {/* ลบข้อมูลตัวเลือกบริการ */}
-                    <Button
-                      variant="outline"
-                      size="icon"
+                    <TableActionButton
                       aria-label="ลบข้อมูล"
+                      icon={TABLE_ACTION_ICONS.delete}
                       onClick={() => {
                         setSelectedVariant(variant);
                         setIsDeleteDialogOpen(true);
                       }}
-                    >
-                      <TrashIcon className="size-3.5" />
-                    </Button>
+                    />
+                    </div>
                   </TableCell>
                 </TableRow>
               ))

--- a/modules/service/components/ServiceVariantManagement.tsx
+++ b/modules/service/components/ServiceVariantManagement.tsx
@@ -8,10 +8,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  TableActionButton,
-  TABLE_ACTION_ICONS,
-} from "@/components/shared/TableActionButton";
+import { TableActionButton } from "@/components/shared/TableActionButton";
 import { useState } from "react";
 import { PET_TYPE_LABELS } from "@/lib/constants/pet-type";
 import { PET_SIZE_LABELS } from "@/lib/constants/service-type";
@@ -75,7 +72,7 @@ export default function ServiceVariantsManagement({
                     {/* แก้ไขข้อมูลตัวเลือกบริการ */}
                     <TableActionButton
                       aria-label="แก้ไขข้อมูล"
-                      icon={TABLE_ACTION_ICONS.edit}
+                      action="edit"
                       onClick={() => {
                         setSelectedVariant(variant);
                         setIsEditDialogOpen(true);
@@ -85,7 +82,7 @@ export default function ServiceVariantsManagement({
                     {/* ลบข้อมูลตัวเลือกบริการ */}
                     <TableActionButton
                       aria-label="ลบข้อมูล"
-                      icon={TABLE_ACTION_ICONS.delete}
+                      action="delete"
                       onClick={() => {
                         setSelectedVariant(variant);
                         setIsDeleteDialogOpen(true);

--- a/modules/transaction-category/components/TransactionCategoryManagement.tsx
+++ b/modules/transaction-category/components/TransactionCategoryManagement.tsx
@@ -9,10 +9,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import {
-  TableActionButton,
-  TABLE_ACTION_ICONS,
-} from "@/components/shared/TableActionButton";
+import { TableActionButton } from "@/components/shared/TableActionButton";
 import { useState } from "react";
 import { CreateTransactionCategoryDialog } from "./CreateTransactionCategoryDialog";
 import {
@@ -74,7 +71,7 @@ export function TransactionCategoryManagement({
                     {/* ปุ่มแก้ไขข้อมูลหมวดหมู่ */}
                     <TableActionButton
                       aria-label="แก้ไขข้อมูล"
-                      icon={TABLE_ACTION_ICONS.edit}
+                      action="edit"
                       onClick={() => {
                         setSelectedTransactionCategory(category);
                         setIsUpdateDialogOpen(true);
@@ -84,7 +81,7 @@ export function TransactionCategoryManagement({
                     {/* ปุ่มลบข้อมูลหมวดหมู่ */}
                     <TableActionButton
                       aria-label="ลบข้อมูล"
-                      icon={TABLE_ACTION_ICONS.delete}
+                      action="delete"
                       onClick={() => {
                         setSelectedTransactionCategory(category);
                         setIsDeleteDialogOpen(true);

--- a/modules/transaction-category/components/TransactionCategoryManagement.tsx
+++ b/modules/transaction-category/components/TransactionCategoryManagement.tsx
@@ -9,8 +9,10 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { PencilIcon, TrashIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import {
+  TableActionButton,
+  TABLE_ACTION_ICONS,
+} from "@/components/shared/TableActionButton";
 import { useState } from "react";
 import { CreateTransactionCategoryDialog } from "./CreateTransactionCategoryDialog";
 import {
@@ -67,32 +69,28 @@ export function TransactionCategoryManagement({
                       {TRANSACTION_TYPE_LABELS[category.type]}
                     </Badge>
                   </TableCell>
-                  <TableCell className="space-x-2 text-right">
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
                     {/* ปุ่มแก้ไขข้อมูลหมวดหมู่ */}
-                    <Button
-                      variant="outline"
-                      size="icon"
+                    <TableActionButton
                       aria-label="แก้ไขข้อมูล"
+                      icon={TABLE_ACTION_ICONS.edit}
                       onClick={() => {
                         setSelectedTransactionCategory(category);
                         setIsUpdateDialogOpen(true);
                       }}
-                    >
-                      <PencilIcon className="size-3.5" />
-                    </Button>
+                    />
 
                     {/* ปุ่มลบข้อมูลหมวดหมู่ */}
-                    <Button
-                      variant="outline"
-                      size="icon"
+                    <TableActionButton
                       aria-label="ลบข้อมูล"
+                      icon={TABLE_ACTION_ICONS.delete}
                       onClick={() => {
                         setSelectedTransactionCategory(category);
                         setIsDeleteDialogOpen(true);
                       }}
-                    >
-                      <TrashIcon className="size-3.5" />
-                    </Button>
+                    />
+                    </div>
                   </TableCell>
                 </TableRow>
               ))

--- a/modules/transaction/components/TransactionsTable.tsx
+++ b/modules/transaction/components/TransactionsTable.tsx
@@ -10,10 +10,7 @@ import {
 } from "@/components/ui/table";
 import { Transaction } from "../types/transaction";
 import { formatCurrency, formatThaiDate } from "@/lib/utils";
-import {
-  TableActionButton,
-  TABLE_ACTION_ICONS,
-} from "@/components/shared/TableActionButton";
+import { TableActionButton } from "@/components/shared/TableActionButton";
 
 interface TransactionsTableProps {
   transactions: Transaction[];
@@ -68,9 +65,9 @@ export function TransactionsTable({
                 <div className="flex justify-center gap-1">
                   <TableActionButton
                     variant="ghost"
-                    className="size-8 text-muted-foreground"
+                    className="size-8"
                     aria-label="แก้ไข"
-                    icon={TABLE_ACTION_ICONS.edit}
+                    action="edit"
                     onClick={() => onEdit(tx)}
                     disabled={!tx.isManual}
                     title={
@@ -81,9 +78,9 @@ export function TransactionsTable({
                   />
                   <TableActionButton
                     variant="ghost"
-                    className="size-8 text-muted-foreground hover:text-destructive"
+                    className="size-8"
                     aria-label="ลบ"
-                    icon={TABLE_ACTION_ICONS.delete}
+                    action="delete"
                     onClick={() => onDelete(tx)}
                     disabled={!tx.isManual}
                     title={

--- a/modules/transaction/components/TransactionsTable.tsx
+++ b/modules/transaction/components/TransactionsTable.tsx
@@ -10,8 +10,10 @@ import {
 } from "@/components/ui/table";
 import { Transaction } from "../types/transaction";
 import { formatCurrency, formatThaiDate } from "@/lib/utils";
-import { Pencil, Trash2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import {
+  TableActionButton,
+  TABLE_ACTION_ICONS,
+} from "@/components/shared/TableActionButton";
 
 interface TransactionsTableProps {
   transactions: Transaction[];
@@ -64,10 +66,11 @@ export function TransactionsTable({
               </TableCell>
               <TableCell className="text-center">
                 <div className="flex justify-center gap-1">
-                  <Button
+                  <TableActionButton
                     variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 text-muted-foreground"
+                    className="size-8 text-muted-foreground"
+                    aria-label="แก้ไข"
+                    icon={TABLE_ACTION_ICONS.edit}
                     onClick={() => onEdit(tx)}
                     disabled={!tx.isManual}
                     title={
@@ -75,23 +78,18 @@ export function TransactionsTable({
                         ? "ไม่สามารถแก้ไขรายการอัตโนมัติได้"
                         : "แก้ไข"
                     }
-                  >
-                    <Pencil className="h-4 w-4" />
-                    <span className="sr-only">แก้ไข</span>
-                  </Button>
-                  <Button
+                  />
+                  <TableActionButton
                     variant="ghost"
-                    size="icon"
-                    className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                    className="size-8 text-muted-foreground hover:text-destructive"
+                    aria-label="ลบ"
+                    icon={TABLE_ACTION_ICONS.delete}
                     onClick={() => onDelete(tx)}
                     disabled={!tx.isManual}
                     title={
                       !tx.isManual ? "ไม่สามารถลบรายการอัตโนมัติได้" : "ลบ"
                     }
-                  >
-                    <Trash2 className="h-4 w-4" />
-                    <span className="sr-only">ลบ</span>
-                  </Button>
+                  />
                 </div>
               </TableCell>
             </TableRow>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * เพิ่มคอมโพเนนต์ปุ่มการดำเนินการแบบใช้ร่วมกันสำหรับตาราง (รองรับลิงก์และปุ่มพร้อมสถานะโหลด)

* **Style**
  * ทำให้ปุ่มการดำเนินการในตารางทั่วแอปสอดคล้องกัน
  * ปรับการจัดวางช่องการจัดการเป็นการจัดชิดขวาและเว้นช่องว่างระหว่างปุ่ม
  * ปรับปรุงการแสดงไอคอนและสถานะโหลดของปุ่มการดำเนินการ
<!-- end of auto-generated comment: release notes by coderabbit.ai -->